### PR TITLE
feat-562: rearrange columns in column menu via drag and drop

### DIFF
--- a/src/assets/icons/ArrangeColumns.tsx
+++ b/src/assets/icons/ArrangeColumns.tsx
@@ -1,0 +1,10 @@
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
+import { mdiReorderVertical } from "@mdi/js";
+
+export default function ArrangeColumns(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d={mdiReorderVertical} />
+    </SvgIcon>
+  );
+}

--- a/src/components/Table/ColumnMenu/ArrangeColumns.tsx
+++ b/src/components/Table/ColumnMenu/ArrangeColumns.tsx
@@ -1,0 +1,132 @@
+import { IMenuModalProps } from ".";
+import React, { useEffect, useState } from "react";
+
+import _orderBy from "lodash/orderBy";
+import _sortBy from "lodash/sortBy";
+import DataGrid, { Column, Row, RowRendererProps } from "react-data-grid";
+import { DndProvider, useDrag, useDrop } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+import Modal from "@src/components/Modal";
+import { useProjectContext } from "@src/contexts/ProjectContext";
+import useCombinedRefs from "@src/hooks/useCombinedRefs";
+
+type DataGridColumn = Column<any> & {
+  [key: string]: any;
+};
+export default function ArrangeColumn({ open, handleClose }: IMenuModalProps) {
+  const { tableState, tableActions } = useProjectContext();
+  const [arr, setArr] = useState<DataGridColumn[]>([]);
+  const columns = [
+    {
+      key: "index",
+      name: "Order",
+      type: "Arrange_Column",
+      index: 0,
+      width: 90,
+      headerCellClass: "arrange-column-index-header",
+      cellClass: "arrange-column-index-cell",
+      editable: false,
+    },
+    {
+      key: "name",
+      name: "Column Name",
+      type: "Arrange_Column",
+      index: 0,
+      width: 220,
+      headerCellClass: "arrange-column-name-header",
+      cellClass: "arrange-column-name-cell",
+      editable: false,
+    },
+  ];
+
+  const handleArrangeColumn = () => tableActions?.column.arrange(arr);
+
+  useEffect(() => {
+    if (!tableState?.loadingColumns && tableState?.columns) {
+      const _rows: DataGridColumn[] = _orderBy(
+        Object.values(tableState?.columns!),
+        "index"
+      );
+      setArr(_rows);
+    }
+  }, [tableState?.loadingColumns, tableState?.columns]);
+
+  if (!open) return null;
+  return (
+    <Modal
+      onClose={handleClose}
+      title="Arrange Columns"
+      maxWidth="xs"
+      children={
+        <DndProvider backend={HTML5Backend}>
+          <Container arr={arr} setArr={setArr} columns={columns} />
+        </DndProvider>
+      }
+      actions={{
+        primary: {
+          onClick: () => {
+            handleArrangeColumn();
+            handleClose();
+          },
+          children: "Arrange",
+        },
+        secondary: {
+          onClick: handleClose,
+          children: "Cancel",
+        },
+      }}
+    />
+  );
+}
+
+interface IContainer {
+  arr: DataGridColumn[];
+  columns: DataGridColumn[];
+  setArr: React.Dispatch<React.SetStateAction<DataGridColumn[]>>;
+}
+
+function Container({ arr, columns, setArr }: IContainer) {
+  function arrangeRow(sourceIndex: number, targetIndex: number) {
+    if (arr.length <= 1) return;
+    const newArr: any = Array.from(
+      arr.map((row, index) => {
+        if (index === sourceIndex) return { ...arr[targetIndex], index };
+        if (index === targetIndex) return { ...arr[sourceIndex], index };
+        return row;
+      })
+    );
+    setArr(newArr);
+  }
+
+  function MyRowRenderer(props: RowRendererProps<typeof Row>) {
+    const [{ isDragging }, drag] = useDrag({
+      item: { type: "ROW_DRAG", cellIndex: props.rowIdx },
+      collect: (monitor) => ({
+        isDragging: !!monitor.isDragging(),
+      }),
+    });
+
+    const [{ isOver }, drop] = useDrop({
+      accept: "ROW_DRAG",
+      drop: ({ cellIndex }: any) => arrangeRow(cellIndex, props.rowIdx),
+      collect: (monitor) => ({
+        isOver: !!monitor.isOver(),
+        canDrop: !!monitor.canDrop(),
+      }),
+    });
+
+    const ref = useCombinedRefs(drag, drop);
+
+    return <Row ref={ref} {...props} />;
+  }
+
+  return (
+    <DataGrid
+      className="rdg-light"
+      rows={arr}
+      columns={columns}
+      rowRenderer={MyRowRenderer}
+    />
+  );
+}

--- a/src/components/Table/ColumnMenu/ArrangeColumns.tsx
+++ b/src/components/Table/ColumnMenu/ArrangeColumns.tsx
@@ -89,13 +89,11 @@ interface IContainer {
 function Container({ arr, columns, setArr }: IContainer) {
   function arrangeRow(sourceIndex: number, targetIndex: number) {
     if (arr.length <= 1) return;
-    const newArr: any = Array.from(
-      arr.map((row, index) => {
-        if (index === sourceIndex) return { ...arr[targetIndex], index };
-        if (index === targetIndex) return { ...arr[sourceIndex], index };
-        return row;
-      })
-    );
+    const newArr: any = arr.map((row, index) => {
+      if (index === sourceIndex) return { ...arr[targetIndex], index };
+      if (index === targetIndex) return { ...arr[sourceIndex], index };
+      return row;
+    });
     setArr(newArr);
   }
 

--- a/src/components/Table/ColumnMenu/index.tsx
+++ b/src/components/Table/ColumnMenu/index.tsx
@@ -14,6 +14,7 @@ import LockIcon from "@mui/icons-material/LockOutlined";
 import FreezeIcon from "@src/assets/icons/Freeze";
 import UnfreezeIcon from "@src/assets/icons/Unfreeze";
 import CellResizeIcon from "@src/assets/icons/CellResize";
+import ArrangeColumnsIcon from "@src/assets/icons/ArrangeColumns";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import EditIcon from "@mui/icons-material/EditOutlined";
@@ -23,6 +24,7 @@ import ColumnPlusBeforeIcon from "@src/assets/icons/ColumnPlusBefore";
 import ColumnPlusAfterIcon from "@src/assets/icons/ColumnPlusAfter";
 import ColumnRemoveIcon from "@src/assets/icons/ColumnRemove";
 
+import ArrangeColumns from "./ArrangeColumns";
 import MenuContents from "./MenuContents";
 import NameChange from "./NameChange";
 import NewColumn from "./NewColumn";
@@ -45,6 +47,7 @@ enum ModalStates {
   typeChange = "TYPE_CHANGE",
   new = "NEW_COLUMN",
   settings = "COLUMN_SETTINGS",
+  arrangeColumns = "ARRANGE_COLUMNS",
 }
 
 type SelectedColumnHeader = {
@@ -217,6 +220,13 @@ export default function ColumnMenu() {
     },
     { type: "subheader" },
     {
+      label: "Arrange Columns",
+      icon: <ArrangeColumnsIcon />,
+      onClick: () => {
+        setModal({ type: ModalStates.arrangeCol, data: {} });
+      },
+    },
+    {
       label: "Rename…",
       icon: <EditIcon />,
       onClick: () => {
@@ -333,6 +343,10 @@ export default function ColumnMenu() {
       )}
       {column && (
         <>
+          <ArrangeColumns
+            {...menuModalProps}
+            open={modal.type === ModalStates.arrangeColumns}
+          />
           <NameChange
             {...menuModalProps}
             open={modal.type === ModalStates.nameChange}

--- a/src/components/Table/ColumnMenu/index.tsx
+++ b/src/components/Table/ColumnMenu/index.tsx
@@ -223,7 +223,7 @@ export default function ColumnMenu() {
       label: "Arrange Columns",
       icon: <ArrangeColumnsIcon />,
       onClick: () => {
-        setModal({ type: ModalStates.arrangeCol, data: {} });
+        setModal({ type: ModalStates.arrangeColumns, data: {} });
       },
     },
     {

--- a/src/hooks/useTable/index.ts
+++ b/src/hooks/useTable/index.ts
@@ -4,6 +4,7 @@ export type TableActions = {
   // TODO: Stricter types here
   column: {
     add: Function;
+    arrange: Function;
     resize: (index: number, width: number) => void;
     rename: Function;
     remove: Function;
@@ -89,6 +90,7 @@ export default function useTable() {
   const actions: TableActions = {
     column: {
       add: configActions.addColumn,
+      arrange: configActions.arrangeColumns,
       resize: configActions.resize,
       rename: configActions.rename,
       update: configActions.updateColumn,

--- a/src/hooks/useTable/useTableConfig.ts
+++ b/src/hooks/useTable/useTableConfig.ts
@@ -71,6 +71,20 @@ const useTableConfig = (tablePath?: string) => {
     });
   };
 
+  const arrangeColumns = (arrangedCol: any) => {
+    const { columns } = tableConfigState;
+
+    const newColumns: any = arrangedCol.reduce((acc, curr) => {
+      acc[curr.key] = { ...columns[curr.key], index: curr.index };
+      return acc;
+    }, {});
+
+    documentDispatch({
+      action: DocActions.update,
+      data: { columns: newColumns },
+    });
+  };
+
   /**  used for updating the width of column
    *  @param index of column.
    *  @param width number of pixels, eg: 120
@@ -160,6 +174,7 @@ const useTableConfig = (tablePath?: string) => {
     updateColumn,
     updateConfig,
     addColumn,
+    arrangeColumns,
     resize,
     setTable,
     remove,


### PR DESCRIPTION
#562 

- Add "Arrange Columns" into Column Menu
- Selecting Column Menu to open a Modal that allows user to edit column order via Drag and Drop
- Columns are displayed as Row 

One issue I ran into was the style of the DataGrid. The night before it was working fine, but this morning I don't know why it turned white. 

In addition, React-Data-Grid offers drag and drop? but I chose to use ReactDnD