### PR TITLE
fix bug: prevent unintended state mutation

### DIFF
--- a/src/hooks/useTable/useTableConfig.ts
+++ b/src/hooks/useTable/useTableConfig.ts
@@ -77,17 +77,20 @@ const useTableConfig = (tablePath?: string) => {
    */
   const [resize] = useDebouncedCallback((index: number, width: number) => {
     const { columns } = tableConfigState;
-    const numberOfFixedColumns = Object.values(columns).filter(
+    const _columnValues = Object.values(columns);
+    const numberOfFixedColumns = _columnValues.filter(
       (col: any) => col.fixed && !col.hidden
     ).length;
     const columnsArray = _sortBy(
-      Object.values(columns).filter((col: any) => !col.hidden && !col.fixed),
+      _columnValues.filter((col: any) => !col.hidden && !col.fixed),
       "index"
     );
-    let column: any = columnsArray[index - numberOfFixedColumns];
-    column.width = width;
-    let updatedColumns = columns;
-    updatedColumns[column.key] = column;
+    const targetColumn: any = columnsArray[index - numberOfFixedColumns];
+    const updatedColumns = {
+      ...columns,
+      [targetColumn.key]: { ...targetColumn, width },
+    };
+
     documentDispatch({
       action: DocActions.update,
       data: { columns: updatedColumns },


### PR DESCRIPTION
- Use javascript delimiter to create a deep copy of the object
- reactor to allow higher order function to reuse array and readability 