### PR TITLE
fix-bug #559 unpredictable state of tableAction.reorder's function

### DIFF
--- a/src/hooks/useTable/useTableConfig.ts
+++ b/src/hooks/useTable/useTableConfig.ts
@@ -6,7 +6,7 @@ import _sortBy from "lodash/sortBy";
 
 import useDoc, { DocActions } from "../useDoc";
 import { FieldType } from "@src/constants/fields";
-import { arrayMover, formatPath } from "../../utils/fns";
+import { formatPath } from "../../utils/fns";
 import { db, deleteField } from "../../firebase";
 
 export type ColumnConfig = {
@@ -130,17 +130,17 @@ const useTableConfig = (tablePath?: string) => {
    */
   const reorder = (draggedColumnKey: string, droppedColumnKey: string) => {
     const { columns } = tableConfigState;
-    const oldIndex = columns[draggedColumnKey].index;
-    const newIndex = columns[droppedColumnKey].index;
-    const columnsArray = _sortBy(Object.values(columns), "index");
-    arrayMover(columnsArray, oldIndex, newIndex);
-    let updatedColumns = columns;
-
-    columnsArray
-      .filter((c) => c) // arrayMover has a bug creating undefined items
-      .forEach((column: any, index) => {
-        updatedColumns[column.key] = { ...column, index };
-      });
+    const updatedColumns = _sortBy(Object.values(columns), "index").reduce(
+      (acc: any, curr: any, index: number) => {
+        if (curr.key === droppedColumnKey)
+          acc[draggedColumnKey] = { ...columns[draggedColumnKey], index };
+        else if (curr.key === draggedColumnKey)
+          acc[droppedColumnKey] = { ...columns[droppedColumnKey], index };
+        else acc[curr.key] = { ...columns[curr.key], index };
+        return acc;
+      },
+      {}
+    );
     documentDispatch({
       action: DocActions.update,
       data: { columns: updatedColumns },

--- a/src/hooks/useTable/useTableConfig.ts
+++ b/src/hooks/useTable/useTableConfig.ts
@@ -130,17 +130,23 @@ const useTableConfig = (tablePath?: string) => {
    */
   const reorder = (draggedColumnKey: string, droppedColumnKey: string) => {
     const { columns } = tableConfigState;
-    const updatedColumns = _sortBy(Object.values(columns), "index").reduce(
-      (acc: any, curr: any, index: number) => {
-        if (curr.key === droppedColumnKey)
-          acc[draggedColumnKey] = { ...columns[draggedColumnKey], index };
-        else if (curr.key === draggedColumnKey)
-          acc[droppedColumnKey] = { ...columns[droppedColumnKey], index };
-        else acc[curr.key] = { ...columns[curr.key], index };
+    const oldIndex = columns[draggedColumnKey].index;
+    const newIndex = columns[droppedColumnKey].index;
+
+    //sort columns by index, remove drag col, insert it in drop position
+    const sortedColumns = _sortBy(Object.values(columns), "index");
+    const removeCol = sortedColumns.splice(oldIndex, 1);
+    sortedColumns.splice(newIndex, 0, removeCol[0]);
+
+    //itereate and update index to proper value
+    const updatedColumns = sortedColumns.reduce(
+      (acc: any, curr: any, index) => {
+        acc[curr.key] = { ...curr, index };
         return acc;
       },
       {}
     );
+
     documentDispatch({
       action: DocActions.update,
       data: { columns: updatedColumns },

--- a/src/utils/fns.ts
+++ b/src/utils/fns.ts
@@ -5,33 +5,6 @@ import _isPlainObject from "lodash/isPlainObject";
 
 import { TABLE_GROUP_SCHEMAS, TABLE_SCHEMAS } from "@src/config/dbPaths";
 
-/**
- * reposition an element in an array
- * @param arr array
- * @param old_index index of element to be moved
- * @param new_index new position of the moved element
- */
-export const arrayMover = (
-  arr: any[],
-  old_index: number,
-  new_index: number
-) => {
-  while (old_index < 0) {
-    old_index += arr.length;
-  }
-  while (new_index < 0) {
-    new_index += arr.length;
-  }
-  if (new_index >= arr.length) {
-    var k = new_index - arr.length + 1;
-    while (k--) {
-      arr.push(undefined);
-    }
-  }
-  arr.splice(new_index, 0, arr.splice(old_index, 1)[0]);
-  return arr; // for testing purposes
-};
-
 export const missingFieldsReducer =
   (data: any) => (acc: string[], curr: string) => {
     if (data[curr] === undefined) {


### PR DESCRIPTION
#559 
- Use .reduce() to carry out data swap, and 
- transform columns into a correct data structure for dispatch. 

Details about Data swap
- During interaction, 
      if curr.key === a.key, then copy data[b],  index 
      vice versa === b.key, acc[a.key] =  { ...data[a], index }
  
I do request some clarification on the array mover function.
- When is there an undefined element?

I don't fully understand the arrayMover function. 
I think I am missing an edge case, assistance would be awesome. 