### PR TITLE
Feat-600: context menu for row column

### DIFF
--- a/src/components/Table/CellMenu/MenuContent.tsx
+++ b/src/components/Table/CellMenu/MenuContent.tsx
@@ -1,0 +1,42 @@
+import { Menu } from "@mui/material";
+import MenuRow, { IMenuRow } from "./MenuRow";
+
+interface IMenuContents {
+  anchorEl: HTMLElement;
+  open: boolean;
+  handleClose: () => void;
+  items: IMenuRow[];
+}
+
+export function MenuContents({
+  anchorEl,
+  open,
+  handleClose,
+  items,
+}: IMenuContents) {
+  const handleContext = (e: React.MouseEvent) => e.preventDefault();
+  return (
+    <Menu
+      id="cell-context-menu"
+      aria-labelledby="cell-context-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+      sx={{ "& .MuiMenu-paper": { backgroundColor: "background.default" } }}
+      MenuListProps={{ disablePadding: true }}
+      onContextMenu={handleContext}
+    >
+      {items.map((item, indx: number) => (
+        <MenuRow key={indx} {...item} />
+      ))}
+    </Menu>
+  );
+}

--- a/src/components/Table/CellMenu/MenuRow.tsx
+++ b/src/components/Table/CellMenu/MenuRow.tsx
@@ -1,0 +1,16 @@
+import { ListItemIcon, ListItemText, MenuItem } from "@mui/material";
+
+export interface IMenuRow {
+  onClick: () => void;
+  icon: JSX.Element;
+  label: string;
+}
+
+export default function MenuRow({ onClick, icon, label }: IMenuRow) {
+  return (
+    <MenuItem onClick={onClick}>
+      <ListItemIcon>{icon} </ListItemIcon>
+      <ListItemText> {label} </ListItemText>
+    </MenuItem>
+  );
+}

--- a/src/components/Table/CellMenu/index.tsx
+++ b/src/components/Table/CellMenu/index.tsx
@@ -1,0 +1,82 @@
+import { ConstructionOutlined } from "@mui/icons-material";
+import { ListItem, Menu, MenuItem } from "@mui/material";
+import { useProjectContext } from "@src/contexts/ProjectContext";
+import React, { useEffect, useState } from "react";
+
+//This does not belong here
+export type CellMenuRef = {
+  anchorEl: any | null;
+  selectedCell: any | null;
+  setSelectedCell: any | null;
+  setAnchorEl: React.Dispatch<React.SetStateAction<any | null>>;
+  anchorEle;
+};
+
+export default function CellMenu() {
+  const { cellMenuRef, tableState }: any = useProjectContext();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [selectedCell, setSelectedCell] = React.useState<any>(null);
+
+  const open = Boolean(anchorEl);
+
+  if (cellMenuRef)
+    cellMenuRef.current = {
+      anchorEl,
+      setAnchorEl,
+      selectedCell,
+      setSelectedCell,
+    } as {};
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  if (!cellMenuRef.current) return <></>;
+  return (
+    <MenuContents anchorEl={anchorEl} open={open} handleClose={handleClose} />
+  );
+}
+
+const MenuContents = ({ anchorEl, open, handleClose }: any) => {
+  const handleCopy = () => {
+    const input = anchorEl as HTMLElement;
+    const copy = navigator.clipboard.writeText(input.innerHTML);
+    copy.then(
+      () => {
+        console.log("copy");
+        var promise = navigator.clipboard.readText();
+        promise.then((text) => console.log(text));
+      },
+      () => console.log("failed to copy")
+    );
+    handleClose();
+  };
+
+  const handleContext = (e: React.MouseEvent) => {
+    e.preventDefault();
+  };
+  if (!open) return <></>;
+  return (
+    <Menu
+      id="demo-positioned-menu"
+      aria-labelledby="demo-positioned-button"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+      sx={{ "& .MuiMenu-paper": { backgroundColor: "background.default" } }}
+      MenuListProps={{ disablePadding: true }}
+      onContextMenu={handleContext}
+    >
+      <MenuItem onClick={handleCopy}>Copy Cell</MenuItem>
+      <MenuItem onClick={handleCopy}>Copy Cell Id</MenuItem>
+    </Menu>
+  );
+};

--- a/src/components/Table/CellMenu/index.tsx
+++ b/src/components/Table/CellMenu/index.tsx
@@ -1,22 +1,22 @@
-import { ConstructionOutlined } from "@mui/icons-material";
-import { ListItem, Menu, MenuItem } from "@mui/material";
+import React from "react";
+import { PopoverProps } from "@mui/material";
+import CopyCells from "@src/assets/icons/CopyCells";
 import { useProjectContext } from "@src/contexts/ProjectContext";
-import React, { useEffect, useState } from "react";
+import { MenuContents } from "./MenuContent";
 
-//This does not belong here
 export type CellMenuRef = {
-  anchorEl: any | null;
+  anchorEl: null;
   selectedCell: any | null;
-  setSelectedCell: any | null;
-  setAnchorEl: React.Dispatch<React.SetStateAction<any | null>>;
-  anchorEle;
+  setSelectedCell: React.Dispatch<React.SetStateAction<any | null>>;
+  setAnchorEl: React.Dispatch<
+    React.SetStateAction<PopoverProps["anchorEl"] | null>
+  >;
 };
 
 export default function CellMenu() {
-  const { cellMenuRef, tableState }: any = useProjectContext();
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const { cellMenuRef }: any = useProjectContext();
+  const [anchorEl, setAnchorEl] = React.useState<any>(null);
   const [selectedCell, setSelectedCell] = React.useState<any>(null);
-
   const open = Boolean(anchorEl);
 
   if (cellMenuRef)
@@ -27,56 +27,32 @@ export default function CellMenu() {
       setSelectedCell,
     } as {};
 
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  if (!cellMenuRef.current) return <></>;
-  return (
-    <MenuContents anchorEl={anchorEl} open={open} handleClose={handleClose} />
-  );
-}
-
-const MenuContents = ({ anchorEl, open, handleClose }: any) => {
+  const handleClose = () => setAnchorEl(null);
   const handleCopy = () => {
-    const input = anchorEl as HTMLElement;
-    const copy = navigator.clipboard.writeText(input.innerHTML);
-    copy.then(
-      () => {
-        console.log("copy");
-        var promise = navigator.clipboard.readText();
-        promise.then((text) => console.log(text));
-      },
-      () => console.log("failed to copy")
-    );
+    const selected = anchorEl.innerHTML;
+    const copy = navigator.clipboard.writeText(selected);
+    const onSuccess = () => {
+      console.log("Copied");
+      var promise = navigator.clipboard.readText();
+      promise.then((text) => console.log(text));
+    };
+    const onFail = () => console.log("Fail to copy");
+
+    copy.then(onSuccess, onFail);
     handleClose();
   };
 
-  const handleContext = (e: React.MouseEvent) => {
-    e.preventDefault();
-  };
-  if (!open) return <></>;
+  const cellMenuAction = [
+    { label: "Copy", icon: <CopyCells />, color: "", onClick: handleCopy },
+  ];
+
+  if (!cellMenuRef.current || !open) return <></>;
   return (
-    <Menu
-      id="demo-positioned-menu"
-      aria-labelledby="demo-positioned-button"
+    <MenuContents
       anchorEl={anchorEl}
       open={open}
-      onClose={handleClose}
-      anchorOrigin={{
-        vertical: "bottom",
-        horizontal: "left",
-      }}
-      transformOrigin={{
-        vertical: "top",
-        horizontal: "left",
-      }}
-      sx={{ "& .MuiMenu-paper": { backgroundColor: "background.default" } }}
-      MenuListProps={{ disablePadding: true }}
-      onContextMenu={handleContext}
-    >
-      <MenuItem onClick={handleCopy}>Copy Cell</MenuItem>
-      <MenuItem onClick={handleCopy}>Copy Cell Id</MenuItem>
-    </Menu>
+      handleClose={handleClose}
+      items={cellMenuAction}
+    />
   );
-};
+}

--- a/src/components/Table/ColumnMenu/index.tsx
+++ b/src/components/Table/ColumnMenu/index.tsx
@@ -72,9 +72,9 @@ export interface IMenuModalProps {
 
 export default function ColumnMenu() {
   const [modal, setModal] = useState(INITIAL_MODAL);
-  const { tableState, tableActions, columnMenuRef } = useProjectContext();
+  const { tableState, tableActions, cellMenuRef, columnMenuRef } =
+    useProjectContext();
   const { requestConfirmation } = useConfirmation();
-
   const [selectedColumnHeader, setSelectedColumnHeader] = useState<any>(null);
   if (columnMenuRef)
     columnMenuRef.current = {
@@ -83,7 +83,6 @@ export default function ColumnMenu() {
     } as any;
 
   const { column, anchorEl } = (selectedColumnHeader ?? {}) as any;
-
   useEffect(() => {
     if (column && column.type === FieldType.last) {
       setModal({

--- a/src/components/Table/ColumnMenu/index.tsx
+++ b/src/components/Table/ColumnMenu/index.tsx
@@ -72,8 +72,7 @@ export interface IMenuModalProps {
 
 export default function ColumnMenu() {
   const [modal, setModal] = useState(INITIAL_MODAL);
-  const { tableState, tableActions, cellMenuRef, columnMenuRef } =
-    useProjectContext();
+  const { tableState, tableActions, columnMenuRef } = useProjectContext();
   const { requestConfirmation } = useConfirmation();
   const [selectedColumnHeader, setSelectedColumnHeader] = useState<any>(null);
   if (columnMenuRef)

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,4 +1,5 @@
-import { Fragment } from "react";
+import { useProjectContext } from "@src/contexts/ProjectContext";
+import { Fragment, useEffect } from "react";
 import { Row, RowRendererProps } from "react-data-grid";
 
 import OutOfOrderIndicator from "./OutOfOrderIndicator";
@@ -8,9 +9,27 @@ export default function TableRow(props: RowRendererProps<any>) {
     return (
       <Fragment key={props.row.id}>
         <OutOfOrderIndicator top={props.top} height={props.height} />
-        <Row {...props} />
+        <ContextMenuWrapper>
+          <Row {...props} />
+        </ContextMenuWrapper>
       </Fragment>
     );
 
-  return <Row {...props} />;
+  return (
+    <ContextMenuWrapper>
+      {" "}
+      <Row {...props} />
+    </ContextMenuWrapper>
+  );
 }
+///use the react advance pattern here
+const ContextMenuWrapper = (props: any) => {
+  const { cellMenuRef }: any = useProjectContext();
+
+  const handleClick = (e: any) => {
+    e.preventDefault();
+    const input = e?.target as HTMLElement;
+    cellMenuRef.current.setAnchorEl(input);
+  };
+  return <span onContextMenu={handleClick}>{props.children}</span>;
+};

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -31,6 +31,7 @@ import { formatSubTableName } from "@src/utils/fns";
 import { useAppContext } from "@src/contexts/AppContext";
 import { useProjectContext } from "@src/contexts/ProjectContext";
 import useWindowSize from "@src/hooks/useWindowSize";
+import CellMenu from "./CellMenu";
 
 export type TableColumn = Column<any> & {
   isNew?: boolean;
@@ -43,8 +44,14 @@ const rowClass = (row: any) => (row._rowy_outOfOrder ? "out-of-order" : "");
 //const SelectColumn = { ..._SelectColumn, width: 42, maxWidth: 42 };
 
 export default function Table() {
-  const { tableState, tableActions, dataGridRef, sideDrawerRef, updateCell } =
-    useProjectContext();
+  const {
+    tableState,
+    tableActions,
+    dataGridRef,
+    cellMenuRef,
+    sideDrawerRef,
+    updateCell,
+  } = useProjectContext();
   const { userDoc } = useAppContext();
 
   const userDocHiddenFields =
@@ -251,8 +258,8 @@ export default function Table() {
           <Loading message="Fetching columns" />
         )}
       </TableContainer>
-
       <ColumnMenu />
+      <CellMenu />
       <BulkActions
         selectedRows={selectedRows}
         columns={columns}

--- a/src/contexts/ProjectContext.tsx
+++ b/src/contexts/ProjectContext.tsx
@@ -13,6 +13,7 @@ import useTable, { TableActions, TableState } from "@src/hooks/useTable";
 import useSettings from "@src/hooks/useSettings";
 import { useAppContext } from "./AppContext";
 import { SideDrawerRef } from "@src/components/SideDrawer";
+import { CellMenuRef } from "@src/components/Table/CellMenu";
 import { ColumnMenuRef } from "@src/components/Table/ColumnMenu";
 import { ImportWizardRef } from "@src/components/Wizards/ImportWizard";
 
@@ -99,6 +100,8 @@ export interface IProjectContext {
   dataGridRef: React.RefObject<DataGridHandle>;
   // A ref to the side drawer state. Prevents unnecessary re-renders
   sideDrawerRef: React.MutableRefObject<SideDrawerRef | undefined>;
+  //A ref to the cell menu. Prevents unnecessary re-render
+  cellMenuRef: React.MutableRefObject<CellMenuRef | undefined>;
   // A ref to the column menu. Prevents unnecessary re-renders
   columnMenuRef: React.MutableRefObject<ColumnMenuRef | undefined>;
   // A ref ot the import wizard. Prevents unnecessary re-renders
@@ -385,8 +388,10 @@ export const ProjectContextProvider: React.FC = ({ children }) => {
   const dataGridRef = useRef<DataGridHandle>(null);
   const sideDrawerRef = useRef<SideDrawerRef>();
   const columnMenuRef = useRef<ColumnMenuRef>();
+  const cellMenuRef = useRef<CellMenuRef>();
   const importWizardRef = useRef<ImportWizardRef>();
 
+  console.log(cellMenuRef);
   return (
     <ProjectContext.Provider
       value={{
@@ -403,6 +408,7 @@ export const ProjectContextProvider: React.FC = ({ children }) => {
         table,
         dataGridRef,
         sideDrawerRef,
+        cellMenuRef,
         columnMenuRef,
         importWizardRef,
         rowyRun: _rowyRun,

--- a/src/contexts/ProjectContext.tsx
+++ b/src/contexts/ProjectContext.tsx
@@ -391,7 +391,6 @@ export const ProjectContextProvider: React.FC = ({ children }) => {
   const cellMenuRef = useRef<CellMenuRef>();
   const importWizardRef = useRef<ImportWizardRef>();
 
-  console.log(cellMenuRef);
   return (
     <ProjectContext.Provider
       value={{


### PR DESCRIPTION
#600 

I am working on this too. Let's figure out who will take these tasks.

Implemented context menu for rowClick. and a copy cell value function.


Currently, getting the column.key in RowRender is currently blocking me.  
This in turn creates issues with retrieving column values. 
