### PR TITLE
feat-600 add context menu for cells

### DIFF
--- a/src/assets/icons/Paste.tsx
+++ b/src/assets/icons/Paste.tsx
@@ -1,0 +1,10 @@
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
+import { mdiContentPaste } from "@mdi/js";
+
+export default function Paste(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d={mdiContentPaste} />
+    </SvgIcon>
+  );
+}

--- a/src/assets/icons/PasteFromClipboard.tsx
+++ b/src/assets/icons/PasteFromClipboard.tsx
@@ -1,0 +1,10 @@
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon";
+import { mdiClipboardArrowDownOutline } from "@mdi/js";
+
+export default function PasteFromClipboard(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d={mdiClipboardArrowDownOutline} />
+    </SvgIcon>
+  );
+}

--- a/src/components/SideDrawer/index.tsx
+++ b/src/components/SideDrawer/index.tsx
@@ -34,8 +34,8 @@ export default function SideDrawer() {
 
   const [cell, setCell] = useState<SelectedCell>(null);
   const [open, setOpen] = useState(false);
-  if (sideDrawerRef) sideDrawerRef.current = { cell, setCell, open, setOpen };
 
+  if (sideDrawerRef) sideDrawerRef.current = { cell, setCell, open, setOpen };
   const handleNavigate = (direction: "up" | "down") => () => {
     if (!tableState?.rows) return;
 

--- a/src/components/Table/CellMenu/MenuContent.tsx
+++ b/src/components/Table/CellMenu/MenuContent.tsx
@@ -1,0 +1,42 @@
+import { Menu } from "@mui/material";
+import MenuRow, { IMenuRow } from "./MenuRow";
+
+interface IMenuContents {
+  anchorEl: HTMLElement;
+  open: boolean;
+  handleClose: () => void;
+  items: IMenuRow[];
+}
+
+export function MenuContents({
+  anchorEl,
+  open,
+  handleClose,
+  items,
+}: IMenuContents) {
+  const handleContext = (e: React.MouseEvent) => e.preventDefault();
+  return (
+    <Menu
+      id="cell-context-menu"
+      aria-labelledby="cell-context-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+      sx={{ "& .MuiMenu-paper": { backgroundColor: "background.default" } }}
+      MenuListProps={{ disablePadding: true }}
+      onContextMenu={handleContext}
+    >
+      {items.map((item, indx: number) => (
+        <MenuRow key={indx} {...item} />
+      ))}
+    </Menu>
+  );
+}

--- a/src/components/Table/CellMenu/MenuRow.tsx
+++ b/src/components/Table/CellMenu/MenuRow.tsx
@@ -1,0 +1,16 @@
+import { ListItemIcon, ListItemText, MenuItem } from "@mui/material";
+
+export interface IMenuRow {
+  onClick: () => void;
+  icon: JSX.Element;
+  label: string;
+}
+
+export default function MenuRow({ onClick, icon, label }: IMenuRow) {
+  return (
+    <MenuItem onClick={onClick}>
+      <ListItemIcon>{icon} </ListItemIcon>
+      <ListItemText> {label} </ListItemText>
+    </MenuItem>
+  );
+}

--- a/src/components/Table/CellMenu/index.tsx
+++ b/src/components/Table/CellMenu/index.tsx
@@ -1,10 +1,23 @@
 import React from "react";
 import { PopoverProps } from "@mui/material";
 import CopyCells from "@src/assets/icons/CopyCells";
+import Paste from "@src/assets/icons/Paste";
 import { useProjectContext } from "@src/contexts/ProjectContext";
 import { MenuContents } from "./MenuContent";
+import _find from "lodash/find";
+import { atom, useAtom } from "jotai";
+import PasteFromClipboard from "@src/assets/icons/PasteFromClipboard";
+
+export const cellMenuDataAtom = atom("");
+
+export type SelectedCell = {
+  rowIndex: number;
+  colIndex: number;
+};
 
 export type CellMenuRef = {
+  selectedCell: SelectedCell;
+  setSelectedCell: React.Dispatch<React.SetStateAction<SelectedCell | null>>;
   anchorEl: HTMLElement | null;
   setAnchorEl: React.Dispatch<
     React.SetStateAction<PopoverProps["anchorEl"] | null>
@@ -12,33 +25,63 @@ export type CellMenuRef = {
 };
 
 export default function CellMenu() {
-  const { cellMenuRef }: any = useProjectContext();
+  const { cellMenuRef, tableState, updateCell }: any = useProjectContext();
   const [anchorEl, setAnchorEl] = React.useState<any | null>(null);
+  const [selectedCell, setSelectedCell] = React.useState<any | null>();
+  const [cellMenuData, setCellMenuData] = useAtom(cellMenuDataAtom);
   const open = Boolean(anchorEl);
 
   if (cellMenuRef)
     cellMenuRef.current = {
       anchorEl,
       setAnchorEl,
+      selectedCell,
+      setSelectedCell,
     } as {};
 
   const handleClose = () => setAnchorEl(null);
   const handleCopy = () => {
-    const selected: any = anchorEl?.innerHTML;
-    const copy = navigator.clipboard.writeText(selected);
-    const onSuccess = () => {
-      console.log("Copied");
-      var promise = navigator.clipboard.readText();
-      promise.then((text) => console.log(text));
-    };
+    const cols = _find(tableState.columns, { index: selectedCell.colIndex });
+    const rows = tableState.rows[selectedCell.rowIndex];
+    const cell = rows[cols.key];
+    const formatData = typeof cell === "object" ? JSON.stringify(cell) : cell;
+    setCellMenuData(formatData);
     const onFail = () => console.log("Fail to copy");
+    const onSuccess = () => console.log;
 
+    const copy = navigator.clipboard.writeText(formatData);
     copy.then(onSuccess, onFail);
+
+    handleClose();
+  };
+  const handlePaste = () => {
+    const targetCol = _find(tableState.columns, {
+      index: selectedCell.colIndex,
+    });
+    const targetRow = tableState.rows[selectedCell.rowIndex];
+    if (cellMenuData) updateCell(targetRow.ref, targetCol.key, cellMenuData);
     handleClose();
   };
 
+  const handlePasteFromClipboard = () => {
+    const paste = navigator.clipboard.readText();
+    const targetCol = _find(tableState.columns, {
+      index: selectedCell.colIndex,
+    });
+    const targetRow = tableState.rows[selectedCell.rowIndex];
+    paste.then((clipText) =>
+      updateCell(targetRow.ref, targetCol.key, clipText)
+    );
+  };
+
   const cellMenuAction = [
-    { label: "Copy", icon: <CopyCells />, color: "", onClick: handleCopy },
+    { label: "Copy", icon: <CopyCells />, onClick: handleCopy },
+    { label: "Paste", icon: <Paste />, onClick: handlePaste },
+    {
+      label: "Paste from Clipboard",
+      icon: <PasteFromClipboard />,
+      onClick: handlePasteFromClipboard,
+    },
   ];
 
   if (!cellMenuRef.current || !open) return <></>;

--- a/src/components/Table/CellMenu/index.tsx
+++ b/src/components/Table/CellMenu/index.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { PopoverProps } from "@mui/material";
+import CopyCells from "@src/assets/icons/CopyCells";
+import { useProjectContext } from "@src/contexts/ProjectContext";
+import { MenuContents } from "./MenuContent";
+
+export type CellMenuRef = {
+  anchorEl: HTMLElement | null;
+  setAnchorEl: React.Dispatch<
+    React.SetStateAction<PopoverProps["anchorEl"] | null>
+  >;
+};
+
+export default function CellMenu() {
+  const { cellMenuRef }: any = useProjectContext();
+  const [anchorEl, setAnchorEl] = React.useState<any | null>(null);
+  const open = Boolean(anchorEl);
+
+  if (cellMenuRef)
+    cellMenuRef.current = {
+      anchorEl,
+      setAnchorEl,
+    } as {};
+
+  const handleClose = () => setAnchorEl(null);
+  const handleCopy = () => {
+    const selected: any = anchorEl?.innerHTML;
+    const copy = navigator.clipboard.writeText(selected);
+    const onSuccess = () => {
+      console.log("Copied");
+      var promise = navigator.clipboard.readText();
+      promise.then((text) => console.log(text));
+    };
+    const onFail = () => console.log("Fail to copy");
+
+    copy.then(onSuccess, onFail);
+    handleClose();
+  };
+
+  const cellMenuAction = [
+    { label: "Copy", icon: <CopyCells />, color: "", onClick: handleCopy },
+  ];
+
+  if (!cellMenuRef.current || !open) return <></>;
+  return (
+    <MenuContents
+      anchorEl={anchorEl}
+      open={open}
+      handleClose={handleClose}
+      items={cellMenuAction}
+    />
+  );
+}

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,5 +1,5 @@
 import { useProjectContext } from "@src/contexts/ProjectContext";
-import { Fragment, useEffect } from "react";
+import { Fragment } from "react";
 import { Row, RowRendererProps } from "react-data-grid";
 
 import OutOfOrderIndicator from "./OutOfOrderIndicator";

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,4 +1,5 @@
-import { Fragment } from "react";
+import { useProjectContext } from "@src/contexts/ProjectContext";
+import { Fragment, useEffect } from "react";
 import { Row, RowRendererProps } from "react-data-grid";
 
 import OutOfOrderIndicator from "./OutOfOrderIndicator";
@@ -8,9 +9,26 @@ export default function TableRow(props: RowRendererProps<any>) {
     return (
       <Fragment key={props.row.id}>
         <OutOfOrderIndicator top={props.top} height={props.height} />
-        <Row {...props} />
+        <ContextMenu>
+          <Row {...props} />
+        </ContextMenu>
       </Fragment>
     );
 
-  return <Row {...props} />;
+  return (
+    <ContextMenu>
+      <Row {...props} />
+    </ContextMenu>
+  );
 }
+
+const ContextMenu = (props: any) => {
+  const { cellMenuRef }: any = useProjectContext();
+
+  const handleClick = (e: any) => {
+    e.preventDefault();
+    const input = e?.target as HTMLElement;
+    cellMenuRef.current.setAnchorEl(input);
+  };
+  return <span onContextMenu={handleClick}>{props.children}</span>;
+};

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -44,8 +44,14 @@ const rowClass = (row: any) => (row._rowy_outOfOrder ? "out-of-order" : "");
 //const SelectColumn = { ..._SelectColumn, width: 42, maxWidth: 42 };
 
 export default function Table() {
-  const { tableState, tableActions, dataGridRef, sideDrawerRef, updateCell } =
-    useProjectContext();
+  const {
+    tableState,
+    tableActions,
+    dataGridRef,
+    cellMenuRef,
+    sideDrawerRef,
+    updateCell,
+  } = useProjectContext();
   const { userDoc } = useAppContext();
 
   const userDocHiddenFields =
@@ -245,6 +251,12 @@ export default function Table() {
                     column: column.key,
                   });
                 }
+              }}
+              onSelectedCellChange={({ rowIdx, idx }) => {
+                cellMenuRef?.current?.setSelectedCell({
+                  rowIndex: rowIdx,
+                  colIndex: idx,
+                });
               }}
             />
           </DndProvider>

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -17,6 +17,7 @@ import DataGrid, {
 import Loading from "@src/components/Loading";
 import TableContainer, { OUT_OF_ORDER_MARGIN } from "./TableContainer";
 import TableHeader from "../TableHeader";
+import CellMenu from "./CellMenu";
 import ColumnHeader from "./ColumnHeader";
 import ColumnMenu from "./ColumnMenu";
 import FinalColumnHeader from "./FinalColumnHeader";
@@ -251,8 +252,8 @@ export default function Table() {
           <Loading message="Fetching columns" />
         )}
       </TableContainer>
-
       <ColumnMenu />
+      <CellMenu />
       <BulkActions
         selectedRows={selectedRows}
         columns={columns}

--- a/src/contexts/ProjectContext.tsx
+++ b/src/contexts/ProjectContext.tsx
@@ -13,6 +13,7 @@ import useTable, { TableActions, TableState } from "@src/hooks/useTable";
 import useSettings from "@src/hooks/useSettings";
 import { useAppContext } from "./AppContext";
 import { SideDrawerRef } from "@src/components/SideDrawer";
+import { CellMenuRef } from "@src/components/Table/CellMenu";
 import { ColumnMenuRef } from "@src/components/Table/ColumnMenu";
 import { ImportWizardRef } from "@src/components/Wizards/ImportWizard";
 
@@ -99,6 +100,8 @@ export interface IProjectContext {
   dataGridRef: React.RefObject<DataGridHandle>;
   // A ref to the side drawer state. Prevents unnecessary re-renders
   sideDrawerRef: React.MutableRefObject<SideDrawerRef | undefined>;
+  //A ref to the cell menu. Prevents unnecessary re-render
+  cellMenuRef: React.MutableRefObject<CellMenuRef | undefined>;
   // A ref to the column menu. Prevents unnecessary re-renders
   columnMenuRef: React.MutableRefObject<ColumnMenuRef | undefined>;
   // A ref ot the import wizard. Prevents unnecessary re-renders
@@ -385,6 +388,7 @@ export const ProjectContextProvider: React.FC = ({ children }) => {
   const dataGridRef = useRef<DataGridHandle>(null);
   const sideDrawerRef = useRef<SideDrawerRef>();
   const columnMenuRef = useRef<ColumnMenuRef>();
+  const cellMenuRef = useRef<CellMenuRef>();
   const importWizardRef = useRef<ImportWizardRef>();
 
   return (
@@ -403,6 +407,7 @@ export const ProjectContextProvider: React.FC = ({ children }) => {
         table,
         dataGridRef,
         sideDrawerRef,
+        cellMenuRef,
         columnMenuRef,
         importWizardRef,
         rowyRun: _rowyRun,


### PR DESCRIPTION
#600 
Implementation of Context Menu for Row's Cell

ContextMenu Component Wraps DataGrid's Row Component in Table Row Component.
Used a similar structure as the Column Menu, using a single CellMenuRef for the anchor position
Currently copied text is grabbed by calling anchorEl.innerHTML

Problems in the foreseeable feature
1. Need to think through if we want to integrate with #598 and other hotkey functions
2. Selecting the cell column.key is blocking me because the rowRendererProps passed to React Data Grid's Row does not contain column property. We need to figure out how to find the column.key. We can probably do a hacky function with DataGrid's onRow click, but I feel like there has to be a better. 
