### PR TITLE
Added confirmation for Duplicate Row button

### DIFF
--- a/src/components/Table/ContextMenu/MenuContents.tsx
+++ b/src/components/Table/ContextMenu/MenuContents.tsx
@@ -137,6 +137,12 @@ export default function MenuContents({ onClose }: IMenuContentsProps) {
 
   // Row actions
   if (row) {
+    const handleDuplicate = () => {
+      addRow({
+        row,
+        setId: addRowIdType === "custom" ? "decrement" : addRowIdType,
+      });
+    };
     const handleDelete = () => deleteRow(row._rowy_ref.path);
     const rowActions = [
       {
@@ -179,13 +185,28 @@ export default function MenuContents({ onClose }: IMenuContentsProps) {
             disabled:
               tableSettings.tableType === "collectionGroup" ||
               (!userRoles.includes("ADMIN") && tableSettings.readOnly),
-            onClick: () => {
-              addRow({
-                row,
-                setId: addRowIdType === "custom" ? "decrement" : addRowIdType,
-              });
-              onClose();
-            },
+            onClick: altPress
+              ? handleDuplicate
+              : () => {
+                  confirm({
+                    title: "Duplicate row?",
+                    body: (
+                      <>
+                        Row path:
+                        <br />
+                        <code
+                          style={{ userSelect: "all", wordBreak: "break-all" }}
+                        >
+                          {row._rowy_ref.path}
+                        </code>
+                      </>
+                    ),
+                    confirm: "Duplicate",
+                    confirmColor: "success",
+                    handleConfirm: handleDuplicate,
+                  });
+                  onClose();
+                },
           },
           {
             label: altPress ? "Delete" : "Delete…",

--- a/src/components/Table/formatters/FinalColumn.tsx
+++ b/src/components/Table/formatters/FinalColumn.tsx
@@ -31,6 +31,12 @@ export default function FinalColumn({ row }: FormatterProps<TableRow, any>) {
 
   const [altPress] = useAtom(altPressAtom, projectScope);
   const handleDelete = () => deleteRow(row._rowy_ref.path);
+  const handleDuplicate = () => {
+    addRow({
+      row,
+      setId: addRowIdType === "custom" ? "decrement" : addRowIdType,
+    });
+  };
 
   if (!userRoles.includes("ADMIN") && tableSettings.readOnly === true)
     return null;
@@ -42,11 +48,28 @@ export default function FinalColumn({ row }: FormatterProps<TableRow, any>) {
           size="small"
           color="inherit"
           disabled={tableSettings.tableType === "collectionGroup"}
-          onClick={() =>
-            addRow({
-              row,
-              setId: addRowIdType === "custom" ? "decrement" : addRowIdType,
-            })
+          onClick={
+            altPress
+              ? handleDuplicate
+              : () => {
+                  confirm({
+                    title: "Duplicate row?",
+                    body: (
+                      <>
+                        Row path:
+                        <br />
+                        <code
+                          style={{ userSelect: "all", wordBreak: "break-all" }}
+                        >
+                          {row._rowy_ref.path}
+                        </code>
+                      </>
+                    ),
+                    confirm: "Duplicate",
+                    confirmColor: "success",
+                    handleConfirm: handleDuplicate,
+                  });
+                }
           }
           aria-label="Duplicate row"
           className="row-hover-iconButton"


### PR DESCRIPTION
Fixes #739

This PR adds a confirmation modal for adding a duplicate row.

### Screenshot of the change
<img width="960" alt="image" src="https://user-images.githubusercontent.com/53828745/190631464-6701cb82-2252-42c5-b9c6-d441ac2ea001.png">
