### PR TITLE
#513: Added Customizable Icons for Ratings Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Connect to your database, manage data in table-UI with role based access control
 
 Set up Rowy on your Google Cloud Platform project with this easy deploy button.
 
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.rowy.app/)
+[<img width="250" alt="Guided quick start button" src="https://user-images.githubusercontent.com/307298/185548050-e9208fb6-fe53-4c84-bbfa-53c08e03c15f.png">](https://rowy.app/)
 
-https://deploy.rowy.app/
+https://rowy.app
 
 ## Documentation
 
@@ -91,7 +91,7 @@ https://user-images.githubusercontent.com/307298/157185793-f67511cd-7b7b-4229-95
 
 Set up Rowy on your Google Cloud project with this one-click deploy button. Your data and cloud functions stay on your own Firestore/GCP.
 
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.rowy.app/)
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://rowy.app/)
 
 The one-click deploy makes the process of setting up easy with a step by step
 guide and ensures your project is setup correctly.

--- a/src/components/fields/Rating/Settings.tsx
+++ b/src/components/fields/Rating/Settings.tsx
@@ -1,8 +1,9 @@
 import { ISettingsProps } from "@src/components/fields/types";
 import RatingIcon from "@mui/icons-material/Star";
-import { Slider, InputLabel, TextField, Grid, FormControlLabel, Checkbox, Stack, Fab } from "@mui/material";
+import { InputLabel, TextField, Grid, FormControlLabel, Checkbox, Stack } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import MuiRating from "@mui/material/Rating";
 import { get } from "lodash-es";
 
 export default function Settings({ onChange, config }: ISettingsProps) {
@@ -10,18 +11,20 @@ export default function Settings({ onChange, config }: ISettingsProps) {
     <Grid container spacing={2} justifyItems="end" direction={"row"}>
       <Grid item xs={6}>
         <TextField
-          label="Maximum number of stars"
+          label="Highest possible rating"
           type={"number"}
           value={config.max}
           fullWidth
+          error={false}
           onChange={(e) => {
-            onChange("max")(parseInt(e.target.value));
+            let input = parseInt(e.target.value) || 0
+            if (input > 20) { input = 20 }
+            onChange("max")(input);
           }}
-          inputProps={{ min: 1, max: 20 }}
         />
       </Grid>
       <Grid item xs={6}>
-        <InputLabel>Star fraction</InputLabel>
+        <InputLabel>Rating fraction</InputLabel>
         <ToggleButtonGroup
           value={config.precision}
           exclusive
@@ -30,6 +33,7 @@ export default function Settings({ onChange, config }: ISettingsProps) {
             onChange("precision")(value);
           }}
           aria-label="text alignment"
+          sx={{ pt: 0.5 }}
         >
           <ToggleButton value={0.25} aria-label="quarter">
             1/4
@@ -42,38 +46,47 @@ export default function Settings({ onChange, config }: ISettingsProps) {
           </ToggleButton>
         </ToggleButtonGroup>
       </Grid>
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={config.customIcons?.enabled}
-            onChange={(e) =>
-              onChange("customIcons.enabled")(e.target.checked)
-            }
-            name="customIcons.enabled"
-          />
-        }
-        label="Customize button icons with emoji"
-        style={{ marginLeft: -11 }}
-      />
+      <Grid item xs={6}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={config.customIcons?.enabled}
+              onChange={(e) =>
+                onChange("customIcons.enabled")(e.target.checked)
+              }
+              name="customIcons.enabled"
+            />
+          }
+          label="Customize ratings with emoji"
+          style={{ marginLeft: -11 }}
+        />
+      </Grid>
       {config.customIcons?.enabled && (
-        <Grid container spacing={2} sx={{ mt: { xs: 0, sm: -1 } }}>
-          <Grid item xs={12} sm={true}>
-            <Stack direction="row" spacing={1}>
-              <TextField
-                id="customIcons.rating"
-                value={get(config, "customIcons.rating")}
-                onChange={(e) =>
-                  onChange("customIcons.rating")(e.target.value)
-                }
-                label="Rating:"
-                className="labelHorizontal"
-                inputProps={{ style: { width: "3ch" } }}
-              />
-              <Fab size="small" aria-label="Preview of rating button">
-                {get(config, "customIcons.rating") || <RatingIcon />}
-              </Fab>
-            </Stack>
-          </Grid>
+        <Grid item xs={6} sm={true}>
+          <Stack direction="row" spacing={1}>
+            <TextField
+              id="customIcons.rating"
+              value={get(config, "customIcons.rating")}
+              onChange={(e) =>
+                onChange("customIcons.rating")(e.target.value)
+              }
+              label="Custom icon preview:"
+              className="labelHorizontal"
+              inputProps={{ style: { width: "2ch" } }}
+            />
+
+            <MuiRating aria-label="Preview of the rating field with custom icon"
+              name="Preview"
+              onClick={(e) => e.stopPropagation()}
+              icon={get(config, "customIcons.rating") || <RatingIcon />}
+              size="small"
+              emptyIcon={get(config, "customIcons.rating") || <RatingIcon />}
+              max={get(config, "max")}
+              precision={get(config, "precision")}
+              sx={{ pt: 0.5 }}
+            />
+          </Stack>
+
         </Grid>
       )}
     </Grid>

--- a/src/components/fields/Rating/Settings.tsx
+++ b/src/components/fields/Rating/Settings.tsx
@@ -1,48 +1,81 @@
 import { ISettingsProps } from "@src/components/fields/types";
-
-import { Slider, InputLabel, TextField, Grid } from "@mui/material";
+import RatingIcon from "@mui/icons-material/Star";
+import { Slider, InputLabel, TextField, Grid, FormControlLabel, Checkbox, Stack, Fab } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import { get } from "lodash-es";
 
 export default function Settings({ onChange, config }: ISettingsProps) {
   return (
-    <>
-      <Grid container spacing={2} justifyItems="end" direction={"row"}>
-        <Grid item xs={6}>
-          <TextField
-            label="Maximum number of stars"
-            type={"number"}
-            value={config.max}
-            fullWidth
-            onChange={(e) => {
-              onChange("max")(parseInt(e.target.value));
-            }}
-            inputProps={{ min: 1, max: 20 }}
-          />
-        </Grid>
-        <Grid item xs={6}>
-          <InputLabel>Star fraction</InputLabel>
-          <ToggleButtonGroup
-            value={config.precision}
-            exclusive
-            fullWidth
-            onChange={(_, value) => {
-              onChange("precision")(value);
-            }}
-            aria-label="text alignment"
-          >
-            <ToggleButton value={0.25} aria-label="quarter">
-              1/4
-            </ToggleButton>
-            <ToggleButton value={0.5} aria-label="half">
-              1/2
-            </ToggleButton>
-            <ToggleButton value={1} aria-label="whole">
-              1
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </Grid>
+    <Grid container spacing={2} justifyItems="end" direction={"row"}>
+      <Grid item xs={6}>
+        <TextField
+          label="Maximum number of stars"
+          type={"number"}
+          value={config.max}
+          fullWidth
+          onChange={(e) => {
+            onChange("max")(parseInt(e.target.value));
+          }}
+          inputProps={{ min: 1, max: 20 }}
+        />
       </Grid>
-    </>
+      <Grid item xs={6}>
+        <InputLabel>Star fraction</InputLabel>
+        <ToggleButtonGroup
+          value={config.precision}
+          exclusive
+          fullWidth
+          onChange={(_, value) => {
+            onChange("precision")(value);
+          }}
+          aria-label="text alignment"
+        >
+          <ToggleButton value={0.25} aria-label="quarter">
+            1/4
+          </ToggleButton>
+          <ToggleButton value={0.5} aria-label="half">
+            1/2
+          </ToggleButton>
+          <ToggleButton value={1} aria-label="whole">
+            1
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Grid>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={config.customIcons?.enabled}
+            onChange={(e) =>
+              onChange("customIcons.enabled")(e.target.checked)
+            }
+            name="customIcons.enabled"
+          />
+        }
+        label="Customize button icons with emoji"
+        style={{ marginLeft: -11 }}
+      />
+      {config.customIcons?.enabled && (
+        <Grid container spacing={2} sx={{ mt: { xs: 0, sm: -1 } }}>
+          <Grid item xs={12} sm={true}>
+            <Stack direction="row" spacing={1}>
+              <TextField
+                id="customIcons.rating"
+                value={get(config, "customIcons.rating")}
+                onChange={(e) =>
+                  onChange("customIcons.rating")(e.target.value)
+                }
+                label="Rating:"
+                className="labelHorizontal"
+                inputProps={{ style: { width: "3ch" } }}
+              />
+              <Fab size="small" aria-label="Preview of rating button">
+                {get(config, "customIcons.rating") || <RatingIcon />}
+              </Fab>
+            </Stack>
+          </Grid>
+        </Grid>
+      )}
+    </Grid>
   );
 }

--- a/src/components/fields/Rating/Settings.tsx
+++ b/src/components/fields/Rating/Settings.tsx
@@ -1,5 +1,6 @@
 import { ISettingsProps } from "@src/components/fields/types";
 import RatingIcon from "@mui/icons-material/Star";
+import RatingOutlineIcon from "@mui/icons-material/StarBorder"
 import { InputLabel, TextField, Grid, FormControlLabel, Checkbox, Stack } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
@@ -80,7 +81,7 @@ export default function Settings({ onChange, config }: ISettingsProps) {
               onClick={(e) => e.stopPropagation()}
               icon={get(config, "customIcons.rating") || <RatingIcon />}
               size="small"
-              emptyIcon={get(config, "customIcons.rating") || <RatingIcon />}
+              emptyIcon={get(config, "customIcons.rating") || <RatingOutlineIcon />}
               max={get(config, "max")}
               precision={get(config, "precision")}
               sx={{ pt: 0.5 }}

--- a/src/components/fields/Rating/SideDrawerField.tsx
+++ b/src/components/fields/Rating/SideDrawerField.tsx
@@ -3,9 +3,8 @@ import { ISideDrawerFieldProps } from "@src/components/fields/types";
 import { Grid } from "@mui/material";
 import { Rating as MuiRating } from "@mui/material";
 import "@mui/lab";
-import StarBorderIcon from "@mui/icons-material/StarBorder";
-
-import { fieldSx, getFieldId } from "@src/components/SideDrawer/utils";
+import { getStateIcon } from "./TableCell";
+import { fieldSx } from "@src/components/SideDrawer/utils";
 
 export default function Rating({
   column,
@@ -29,7 +28,9 @@ export default function Rating({
           onChange(newValue);
           onSubmit();
         }}
-        emptyIcon={<StarBorderIcon fontSize="inherit" />}
+        icon={getStateIcon(column.config)}
+        emptyIcon={getStateIcon(column.config)}
+        size="small"
         max={max}
         precision={precision}
         sx={{ ml: -0.5 }}

--- a/src/components/fields/Rating/SideDrawerField.tsx
+++ b/src/components/fields/Rating/SideDrawerField.tsx
@@ -3,7 +3,7 @@ import { ISideDrawerFieldProps } from "@src/components/fields/types";
 import { Grid } from "@mui/material";
 import { Rating as MuiRating } from "@mui/material";
 import "@mui/lab";
-import { getStateIcon } from "./TableCell";
+import { getStateIcon, getStateOutline } from "./TableCell";
 import { fieldSx } from "@src/components/SideDrawer/utils";
 
 export default function Rating({
@@ -29,7 +29,7 @@ export default function Rating({
           onSubmit();
         }}
         icon={getStateIcon(column.config)}
-        emptyIcon={getStateIcon(column.config)}
+        emptyIcon={getStateOutline(column.config)}
         size="small"
         max={max}
         precision={precision}

--- a/src/components/fields/Rating/TableCell.tsx
+++ b/src/components/fields/Rating/TableCell.tsx
@@ -2,8 +2,8 @@ import { IHeavyCellProps } from "@src/components/fields/types";
 
 import MuiRating from "@mui/material/Rating";
 import RatingIcon from "@mui/icons-material/Star";
+import RatingOutlineIcon from "@mui/icons-material/StarBorder"
 import { get } from "lodash-es";
-import { MonitorSmall } from "mdi-material-ui";
 
 
 export const getStateIcon = (config: any) => {
@@ -11,6 +11,11 @@ export const getStateIcon = (config: any) => {
   if (!get(config, "customIcons.enabled")) { return <RatingIcon /> }
   return get(config, "customIcons.rating") || <RatingIcon />;
 };
+
+export const getStateOutline = (config: any) => {
+  if (!get(config, "customIcons.enabled")) { return <RatingOutlineIcon /> }
+  return get(config, "customIcons.rating") || <RatingOutlineIcon />;
+}
 
 export default function Rating({
   row,
@@ -41,7 +46,7 @@ export default function Rating({
       size="small"
       disabled={disabled}
       onChange={(_, newValue) => onSubmit(newValue)}
-      emptyIcon={getStateIcon(column.config)}
+      emptyIcon={getStateOutline(column.config)}
       max={max}
       precision={precision}
       sx={{ mx: -0.25 }}

--- a/src/components/fields/Rating/TableCell.tsx
+++ b/src/components/fields/Rating/TableCell.tsx
@@ -1,7 +1,15 @@
 import { IHeavyCellProps } from "@src/components/fields/types";
 
 import MuiRating from "@mui/material/Rating";
-import StarBorderIcon from "@mui/icons-material/StarBorder";
+import RatingIcon from "@mui/icons-material/Star";
+import { get } from "lodash-es";
+
+
+const getStateIcon = (config: any) => {
+  // only use the config to get the custom rating icon if enabled via toggle
+  if (!get(config, "customIcons.enabled")) { return <RatingIcon /> }
+  return get(config, "customIcons.rating") || <RatingIcon />;
+};
 
 export default function Rating({
   row,
@@ -28,9 +36,10 @@ export default function Rating({
       name={`${row.id}-${column.key}`}
       value={typeof value === "number" ? value : 0}
       onClick={(e) => e.stopPropagation()}
+      icon={getStateIcon(column.config)}
       disabled={disabled}
       onChange={(_, newValue) => onSubmit(newValue)}
-      emptyIcon={<StarBorderIcon />}
+      emptyIcon={getStateIcon(column.config)}
       max={max}
       precision={precision}
       sx={{ mx: -0.25 }}

--- a/src/components/fields/Rating/TableCell.tsx
+++ b/src/components/fields/Rating/TableCell.tsx
@@ -3,9 +3,10 @@ import { IHeavyCellProps } from "@src/components/fields/types";
 import MuiRating from "@mui/material/Rating";
 import RatingIcon from "@mui/icons-material/Star";
 import { get } from "lodash-es";
+import { MonitorSmall } from "mdi-material-ui";
 
 
-const getStateIcon = (config: any) => {
+export const getStateIcon = (config: any) => {
   // only use the config to get the custom rating icon if enabled via toggle
   if (!get(config, "customIcons.enabled")) { return <RatingIcon /> }
   return get(config, "customIcons.rating") || <RatingIcon />;
@@ -37,6 +38,7 @@ export default function Rating({
       value={typeof value === "number" ? value : 0}
       onClick={(e) => e.stopPropagation()}
       icon={getStateIcon(column.config)}
+      size="small"
       disabled={disabled}
       onChange={(_, newValue) => onSubmit(newValue)}
       emptyIcon={getStateIcon(column.config)}


### PR DESCRIPTION
#513: Added Customizable Icons for Rating Field

Demonstration here (no audio): https://www.loom.com/share/b4738b9a8a4e45e0bd9c945d9a203388 (Video demo updated to reflect side drawer and icon size updates)

Note: While working on this ticket, I encountered a bug that I created an issue for here #816. I also received some great design feedback that I wish I had time to work on, but don't think I will at the moment (at least during this one day open source challenge!).