### PR TITLE
#816: Fixed Logic for Custom Icons in Action Field

### DIFF
--- a/src/components/fields/Action/ActionFab.tsx
+++ b/src/components/fields/Action/ActionFab.tsx
@@ -40,11 +40,11 @@ const getStateIcon = (actionState: "undo" | "redo" | string, config: any) => {
   }
   switch (actionState) {
     case "undo":
-      return get(config, "customIcons.undo", <UndoIcon />);
+      return get(config, "customIcons.undo") || <UndoIcon />;
     case "redo":
-      return get(config, "customIcons.redo", <RedoIcon />);
+      return get(config, "customIcons.redo") || <RedoIcon />;
     default:
-      return get(config, "customIcons.run", <RunIcon />);
+      return get(config, "customIcons.run") || <RunIcon />;
   }
 };
 

--- a/src/components/fields/Action/ActionFab.tsx
+++ b/src/components/fields/Action/ActionFab.tsx
@@ -28,13 +28,23 @@ const replacer = (data: any) => (m: string, key: string) => {
 };
 
 const getStateIcon = (actionState: "undo" | "redo" | string, config: any) => {
+  if (!get(config, "customIcons.enabled", false)) {
+    switch (actionState) {
+      case "undo":
+        return <UndoIcon />;
+      case "redo":
+        return <RedoIcon />;
+      default:
+        return <RunIcon />;
+    }
+  }
   switch (actionState) {
     case "undo":
-      return get(config, "customIcons.undo") || <UndoIcon />;
+      return get(config, "customIcons.undo", <UndoIcon />);
     case "redo":
-      return get(config, "customIcons.redo") || <RedoIcon />;
+      return get(config, "customIcons.redo", <RedoIcon />);
     default:
-      return get(config, "customIcons.run") || <RunIcon />;
+      return get(config, "customIcons.run", <RunIcon />);
   }
 };
 


### PR DESCRIPTION
Refactored logic in Action Fab to ensure that un-checking the "Custom button icons with emoji" button in the config settings for an Action field will revert icons to default.