### PR TITLE
#816: Fixed Logic for Custom Icons in Action Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Connect to your database, manage data in table-UI with role based access control
 
 Set up Rowy on your Google Cloud Platform project with this easy deploy button.
 
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.rowy.app/)
+[<img width="250" alt="Guided quick start button" src="https://user-images.githubusercontent.com/307298/185548050-e9208fb6-fe53-4c84-bbfa-53c08e03c15f.png">](https://rowy.app/)
 
-https://deploy.rowy.app/
+https://rowy.app
 
 ## Documentation
 
@@ -91,7 +91,7 @@ https://user-images.githubusercontent.com/307298/157185793-f67511cd-7b7b-4229-95
 
 Set up Rowy on your Google Cloud project with this one-click deploy button. Your data and cloud functions stay on your own Firestore/GCP.
 
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.rowy.app/)
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://rowy.app/)
 
 The one-click deploy makes the process of setting up easy with a step by step
 guide and ensures your project is setup correctly.

--- a/src/components/fields/Action/ActionFab.tsx
+++ b/src/components/fields/Action/ActionFab.tsx
@@ -28,6 +28,16 @@ const replacer = (data: any) => (m: string, key: string) => {
 };
 
 const getStateIcon = (actionState: "undo" | "redo" | string, config: any) => {
+  if (!get(config, "customIcons.enabled", false)) {
+    switch (actionState) {
+      case "undo":
+        return <UndoIcon />;
+      case "redo":
+        return <RedoIcon />;
+      default:
+        return <RunIcon />;
+    }
+  }
   switch (actionState) {
     case "undo":
       return get(config, "customIcons.undo") || <UndoIcon />;


### PR DESCRIPTION
Refactored logic in Action Fab to ensure that un-checking the "Custom button icons with emoji" button in the config settings for an Action field will revert icons to default.