### PR TITLE
Changed default Action to script from cloud func

### DIFF
--- a/src/components/fields/Action/Settings.tsx
+++ b/src/components/fields/Action/Settings.tsx
@@ -351,7 +351,7 @@ const Settings = ({ config, onChange, fieldName }: ISettingsProps) => {
                 </RadioGroup>
               </FormControl>
 
-              {config.isCloudFunction ? (
+              {config.isActionScript === false ? (
                 <TextField
                   id="callableName"
                   label="Callable name"
@@ -475,7 +475,7 @@ const Settings = ({ config, onChange, fieldName }: ISettingsProps) => {
             </Stack>
           ),
         },
-        !config.isCloudFunction &&
+        config.isActionScript !== false &&
           get(config, "undo.enabled") && {
             id: "undo",
             title: "Undo action",

--- a/src/components/fields/Action/Settings.tsx
+++ b/src/components/fields/Action/Settings.tsx
@@ -293,13 +293,13 @@ const Settings = ({ config, onChange, fieldName }: ISettingsProps) => {
                 </FormLabel>
                 <RadioGroup
                   aria-label="Action will run"
-                  name="isCloudFunction"
+                  name="isActionScript"
                   value={
-                    config.isCloudFunction ? "cloudFunction" : "actionScript"
+                    config.isActionScript !== false ? "actionScript" : "cloudFunction"
                   }
                   onChange={(e) =>
-                    onChange("isCloudFunction")(
-                      e.target.value === "cloudFunction"
+                    onChange("isActionScript")(
+                      e.target.value === "actionScript"
                     )
                   }
                 >

--- a/src/components/fields/Action/Settings.tsx
+++ b/src/components/fields/Action/Settings.tsx
@@ -293,13 +293,13 @@ const Settings = ({ config, onChange, fieldName }: ISettingsProps) => {
                 </FormLabel>
                 <RadioGroup
                   aria-label="Action will run"
-                  name="isActionScript"
+                  name="isCloudFunction"
                   value={
-                    config.isActionScript ? "actionScript" : "cloudFunction"
+                    config.isCloudFunction ? "cloudFunction" : "actionScript"
                   }
                   onChange={(e) =>
-                    onChange("isActionScript")(
-                      e.target.value === "actionScript"
+                    onChange("isCloudFunction")(
+                      e.target.value === "cloudFunction"
                     )
                   }
                 >
@@ -351,7 +351,7 @@ const Settings = ({ config, onChange, fieldName }: ISettingsProps) => {
                 </RadioGroup>
               </FormControl>
 
-              {!config.isActionScript ? (
+              {config.isCloudFunction ? (
                 <TextField
                   id="callableName"
                   label="Callable name"
@@ -475,7 +475,7 @@ const Settings = ({ config, onChange, fieldName }: ISettingsProps) => {
             </Stack>
           ),
         },
-        config.isActionScript &&
+        !config.isCloudFunction &&
           get(config, "undo.enabled") && {
             id: "undo",
             title: "Undo action",


### PR DESCRIPTION
This PR modifies the settings for the Action field to default to a user-declared script instead of a cloud function that they've already deployed to Firestore/GCP.