### PR TITLE
fix: Build logs collapse by default

### DIFF
--- a/src/components/TableModals/CloudLogsModal/BuildLogs/BuildLogsSnack.tsx
+++ b/src/components/TableModals/CloudLogsModal/BuildLogs/BuildLogsSnack.tsx
@@ -94,7 +94,7 @@ export default function BuildLogsSnack({
         borderRadius: 1,
         zIndex: 1,
         transition: (theme) => theme.transitions.create("height"),
-        height: expanded ? "calc(100% - 300px)" : 300,
+        height: expanded ? "calc(100% - 300px)" : 50,
       }}
     >
       <Box display="flex" justifyContent="space-between" alignItems="center">
@@ -165,7 +165,7 @@ export default function BuildLogsSnack({
         height={"calc(100% - 25px)"}
         id="live-stream-scroll-box-snack"
       >
-        {latestActiveLog && (
+        {latestActiveLog && expanded && (
           <>
             {logs?.map((log: any, index: number) => (
               <BuildLogRow logRecord={log} index={index} key={index} />


### PR DESCRIPTION
PR fixes build logs collapse by default when building derivative column function. 

Fixes #693 

**Changelog**: 
- Fixes `Box` in `BuildLogsSnack.tsx` height if not expanded.
- Hide/Show logs based on `expanded` boolean.

[Demo](https://www.dropbox.com/s/3y55ycho345izxa/rowy_pr.mp4?dl=0)