### PR TITLE
 Fix diff editor dark theme ui

### DIFF
--- a/src/components/CodeEditor/DiffEditor.tsx
+++ b/src/components/CodeEditor/DiffEditor.tsx
@@ -15,6 +15,8 @@ import useMonacoCustomizations, {
 } from "./useMonacoCustomizations";
 import FullScreenButton from "@src/components/FullScreenButton";
 import { spreadSx } from "@src/utils/ui";
+import githubLightTheme from "@src/components/CodeEditor/github-light-default.json";
+import githubDarkTheme from "@src/components/CodeEditor/github-dark-default.json";
 
 export interface IDiffEditorProps
   extends Partial<DiffEditorProps>,
@@ -73,7 +75,12 @@ export default function DiffEditor({
           loading={<CircularProgressOptical size={20} sx={{ m: 2 }} />}
           className="editor"
           {...props}
+          beforeMount={(monaco) => {
+            monaco.editor.defineTheme("github-light", githubLightTheme as any);
+            monaco.editor.defineTheme("github-dark", githubDarkTheme as any);
+          }}
           onMount={handleEditorMount}
+          theme={`github-${theme.palette.mode}`}
           options={
             {
               readOnly: disabled,


### PR DESCRIPTION
This PR applies the same fix that was applied to the code editor, to diff editor.

Before fix:
<img width="861" alt="Screen Shot 2022-11-17 at 12 53 36 pm" src="https://user-images.githubusercontent.com/34177142/202359424-771f177b-9775-40da-8692-bb9b6f81ca13.png">

After fix:
<img width="860" alt="Screen Shot 2022-11-17 at 12 54 38 pm" src="https://user-images.githubusercontent.com/34177142/202359554-7fac3372-5049-4a32-b1af-f837de0b7dfd.png">

