### PR TITLE
#562: Add accessible reorder option in column menu

### DIFF
--- a/src/components/TableToolbar/ManageColumns.tsx
+++ b/src/components/TableToolbar/ManageColumns.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useRef, useMemo, useState } from "react";
+import { useAtom, useSetAtom } from "jotai";
+import { isEqual } from "lodash-es";
+import { colord } from "colord";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+
+import { Box, AutocompleteProps, Theme } from "@mui/material";
+import VisibilityIcon from "@mui/icons-material/VisibilityOutlined";
+// import VisibilityOffIcon from "@mui/icons-material/VisibilityOffOutlined";
+import ViewColumnOutlinedIcon from "@mui/icons-material/ViewColumnOutlined";
+import IconSlash from "@src/components/IconSlash";
+import DragIndicatorOutlinedIcon from "@mui/icons-material/DragIndicatorOutlined";
+
+import ColumnSelect, { ColumnItem } from "@src/components/Table/ColumnSelect";
+import ButtonWithStatus from "@src/components/ButtonWithStatus";
+
+import {
+  globalScope,
+  userSettingsAtom,
+  updateUserSettingsAtom,
+} from "@src/atoms/globalScope";
+import {
+  tableScope,
+  tableIdAtom,
+  updateColumnAtom,
+} from "@src/atoms/tableScope";
+import { formatSubTableName } from "@src/utils/table";
+
+export default function ManageColumns2() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const [userSettings] = useAtom(userSettingsAtom, globalScope);
+  const [tableId] = useAtom(tableIdAtom, tableScope);
+
+  const [open, setOpen] = useState(false);
+
+  // Store local selection here
+  // Initialize hiddenFields from user doc
+  const userDocHiddenFields = useMemo(
+    () =>
+      userSettings.tables?.[formatSubTableName(tableId)]?.hiddenFields ?? [],
+    [userSettings.tables, tableId]
+  );
+
+  const [hiddenFields, setHiddenFields] =
+    useState<string[]>(userDocHiddenFields);
+  useEffect(() => {
+    setHiddenFields(userDocHiddenFields);
+  }, [userDocHiddenFields]);
+
+  // const tableColumns = tableColumnsOrdered.map(({ key, name }) => ({
+  //   value: key,
+  //   label: name,
+  // }));
+
+  // Save when MultiSelect closes
+  const [updateUserSettings] = useAtom(updateUserSettingsAtom, globalScope);
+  const handleSave = () => {
+    // Only update if there were any changes because it’s slow to update
+    if (!isEqual(hiddenFields, userDocHiddenFields) && updateUserSettings) {
+      updateUserSettings({
+        tables: { [formatSubTableName(tableId)]: { hiddenFields } },
+      });
+    }
+
+    setOpen(false);
+  };
+
+  const renderOption: AutocompleteProps<
+    any,
+    true,
+    false,
+    any
+  >["renderOption"] = (props, option, { selected }) => {
+    const slashColor = (theme: Theme) =>
+      colord(theme.palette.background.paper)
+        .mix("#fff", theme.palette.mode === "dark" ? 0.16 : 0)
+        .alpha(1);
+    return (
+      <Draggable draggableId={option.value} index={option.index}>
+        {(provided) => (
+          <li {...props} ref={provided.innerRef} {...provided.draggableProps}>
+            <Box
+              sx={[{ position: "relative", height: "1.5rem" }]}
+              {...provided.dragHandleProps}
+            >
+              <DragIndicatorOutlinedIcon
+                color="disabled"
+                sx={[{ marginRight: "6px" }]}
+              />
+            </Box>
+            <ColumnItem option={option}>
+              <Box
+                sx={[
+                  { position: "relative", height: "1.5rem" },
+                  selected
+                    ? { color: "primary.main" }
+                    : { color: "primary.gray", opacity: 0.6 },
+                ]}
+              >
+                <VisibilityIcon />
+                <IconSlash
+                  sx={[
+                    {
+                      "& .icon-slash-mask": {
+                        stroke: (theme) => slashColor(theme).toHslString(),
+                      },
+                      ".Mui-focused & .icon-slash-mask": {
+                        stroke: (theme) =>
+                          slashColor(theme)
+                            .mix(
+                              theme.palette.primary.main,
+                              theme.palette.action.selectedOpacity +
+                                theme.palette.action.hoverOpacity
+                            )
+                            .alpha(1)
+                            .toHslString(),
+                      },
+                    },
+                    selected ? { strokeDashoffset: 0 } : {},
+                  ]}
+                />
+              </Box>
+            </ColumnItem>
+          </li>
+        )}
+      </Draggable>
+    );
+  };
+
+  const updateColumn = useSetAtom(updateColumnAtom, tableScope);
+  function handleOnDragEnd(result: any) {
+    if (!result.destination) return;
+    updateColumn({
+      key: result.draggableId,
+      config: {},
+      index: result.destination.index,
+    });
+  }
+
+  return (
+    <>
+      <ButtonWithStatus
+        startIcon={<ViewColumnOutlinedIcon />}
+        onClick={() => setOpen((o) => !o)}
+        active={hiddenFields.length > 0}
+        ref={buttonRef}
+      >
+        {"Columns"}
+      </ButtonWithStatus>
+      <DragDropContext onDragEnd={handleOnDragEnd}>
+        <Droppable droppableId="columns_manager" direction="vertical">
+          {(provided) => (
+            <>
+              <ColumnSelect
+                TextFieldProps={{
+                  style: { display: "none" },
+                  SelectProps: {
+                    open,
+                    MenuProps: {
+                      anchorEl: buttonRef.current,
+                      anchorOrigin: { vertical: "bottom", horizontal: "left" },
+                      transformOrigin: { vertical: "top", horizontal: "left" },
+                      sx: {
+                        "& .MuiAutocomplete-listbox .MuiAutocomplete-option[aria-selected=true]":
+                          {
+                            backgroundColor: "transparent",
+                          },
+                      },
+                    },
+                  },
+                }}
+                {...{
+                  AutocompleteProps: {
+                    renderOption,
+                    ListboxProps: {
+                      ...provided.droppableProps,
+                      ref: provided.innerRef,
+                    },
+                  },
+                }}
+                label="Hidden fields"
+                labelPlural="fields"
+                value={hiddenFields ?? []}
+                onChange={setHiddenFields}
+                onClose={handleSave}
+                clearText="Show all"
+                selectAllText="Hide all"
+                doneText="Apply"
+              />
+              {/* <div style={{ display: 'none' }}>
+                {provided.placeholder}
+              </div> */}
+            </>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </>
+  );
+}

--- a/src/components/TableToolbar/ManageColumns.tsx
+++ b/src/components/TableToolbar/ManageColumns.tsx
@@ -1,8 +1,20 @@
-import { useEffect, useRef, useMemo, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useMemo,
+  useState,
+  ChangeEvent,
+  forwardRef,
+} from "react";
 import { useAtom, useSetAtom } from "jotai";
 import { isEqual } from "lodash-es";
 import { colord } from "colord";
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  DropResult,
+} from "react-beautiful-dnd";
 
 import { Box, AutocompleteProps, Theme } from "@mui/material";
 import VisibilityIcon from "@mui/icons-material/VisibilityOutlined";
@@ -26,7 +38,7 @@ import {
 } from "@src/atoms/tableScope";
 import { formatSubTableName } from "@src/utils/table";
 
-export default function ManageColumns2() {
+export default function ManageColumns() {
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const [userSettings] = useAtom(userSettingsAtom, globalScope);
@@ -66,6 +78,9 @@ export default function ManageColumns2() {
     setOpen(false);
   };
 
+  // disable drag if search box is not empty
+  const [disableDrag, setDisableDrag] = useState<boolean>(false);
+
   const renderOption: AutocompleteProps<
     any,
     true,
@@ -77,7 +92,11 @@ export default function ManageColumns2() {
         .mix("#fff", theme.palette.mode === "dark" ? 0.16 : 0)
         .alpha(1);
     return (
-      <Draggable draggableId={option.value} index={option.index}>
+      <Draggable
+        draggableId={option.value}
+        index={option.index}
+        isDragDisabled={disableDrag}
+      >
         {(provided) => (
           <li {...props} ref={provided.innerRef} {...provided.draggableProps}>
             <Box
@@ -86,7 +105,7 @@ export default function ManageColumns2() {
             >
               <DragIndicatorOutlinedIcon
                 color="disabled"
-                sx={[{ marginRight: "6px" }]}
+                sx={[{ marginRight: "6px", opacity: disableDrag ? 0.6 : 1 }]}
               />
             </Box>
             <ColumnItem option={option}>
@@ -95,7 +114,12 @@ export default function ManageColumns2() {
                   { position: "relative", height: "1.5rem" },
                   selected
                     ? { color: "primary.main" }
-                    : { color: "primary.gray", opacity: 0.6 },
+                    : {
+                        opacity: 0,
+                        ".MuiAutocomplete-option.Mui-focused &": {
+                          opacity: 0.5,
+                        },
+                      },
                 ]}
               >
                 <VisibilityIcon />
@@ -129,7 +153,7 @@ export default function ManageColumns2() {
   };
 
   const updateColumn = useSetAtom(updateColumnAtom, tableScope);
-  function handleOnDragEnd(result: any) {
+  function handleOnDragEnd(result: DropResult) {
     if (!result.destination) return;
     updateColumn({
       key: result.draggableId,
@@ -137,6 +161,39 @@ export default function ManageColumns2() {
       index: result.destination.index,
     });
   }
+
+  function checkToDisableDrag(e: ChangeEvent<HTMLInputElement>) {
+    setDisableDrag(e.target.value !== "");
+  }
+
+  const ListboxComponent = forwardRef(function ListboxComponent(
+    props: React.HTMLAttributes<HTMLElement>,
+    ulRef: any /*React.ForwardedRef<HTMLUListElement>*/
+  ) {
+    const { children, ...other } = props;
+
+    return (
+      <DragDropContext onDragEnd={handleOnDragEnd}>
+        <Droppable droppableId="columns_manager" direction="vertical">
+          {(provided) => (
+            <ul
+              {...other}
+              {...provided.droppableProps}
+              ref={(ref) => {
+                provided.innerRef(ref);
+                if (ulRef !== null) {
+                  ulRef(ref);
+                }
+              }}
+            >
+              {props.children}
+              {provided.placeholder}
+            </ul>
+          )}
+        </Droppable>
+      </DragDropContext>
+    );
+  });
 
   return (
     <>
@@ -148,53 +205,48 @@ export default function ManageColumns2() {
       >
         {"Columns"}
       </ButtonWithStatus>
-      <DragDropContext onDragEnd={handleOnDragEnd}>
-        <Droppable droppableId="columns_manager" direction="vertical">
-          {(provided) => (
-            <>
-              <ColumnSelect
-                TextFieldProps={{
-                  style: { display: "none" },
-                  SelectProps: {
-                    open,
-                    MenuProps: {
-                      anchorEl: buttonRef.current,
-                      anchorOrigin: { vertical: "bottom", horizontal: "left" },
-                      transformOrigin: { vertical: "top", horizontal: "left" },
-                      sx: {
-                        "& .MuiAutocomplete-listbox .MuiAutocomplete-option[aria-selected=true]":
-                          {
-                            backgroundColor: "transparent",
-                          },
-                      },
-                    },
+
+      <ColumnSelect
+        TextFieldProps={{
+          style: { display: "none" },
+          onInput: checkToDisableDrag,
+          SelectProps: {
+            open,
+            MenuProps: {
+              anchorEl: buttonRef.current,
+              anchorOrigin: { vertical: "bottom", horizontal: "left" },
+              transformOrigin: { vertical: "top", horizontal: "left" },
+              sx: {
+                "& .MuiAutocomplete-listbox .MuiAutocomplete-option[aria-selected=true]":
+                  {
+                    backgroundColor: "transparent",
                   },
-                }}
-                {...{
-                  AutocompleteProps: {
-                    renderOption,
-                    ListboxProps: {
-                      ...provided.droppableProps,
-                      ref: provided.innerRef,
-                    },
-                  },
-                }}
-                label="Hidden fields"
-                labelPlural="fields"
-                value={hiddenFields ?? []}
-                onChange={setHiddenFields}
-                onClose={handleSave}
-                clearText="Show all"
-                selectAllText="Hide all"
-                doneText="Apply"
-              />
-              {/* <div style={{ display: 'none' }}>
-                {provided.placeholder}
-              </div> */}
-            </>
-          )}
-        </Droppable>
-      </DragDropContext>
+              },
+            },
+          },
+        }}
+        {...{
+          AutocompleteProps: {
+            renderOption,
+            ListboxComponent,
+            // ListboxProps: {
+            //   ...provided.droppableProps,
+            //   ref: provided.innerRef,
+            // },
+          },
+        }}
+        label="Hidden fields"
+        labelPlural="fields"
+        value={hiddenFields ?? []}
+        onChange={(updates: string[]) => {
+          setHiddenFields(updates);
+          setDisableDrag(false);
+        }}
+        onClose={handleSave}
+        clearText="Show all"
+        selectAllText="Hide all"
+        doneText="Apply"
+      />
     </>
   );
 }

--- a/src/components/TableToolbar/TableToolbar.tsx
+++ b/src/components/TableToolbar/TableToolbar.tsx
@@ -15,6 +15,7 @@ import AddRow from "./AddRow";
 import LoadedRowsStatus from "./LoadedRowsStatus";
 import TableSettings from "./TableSettings";
 import HiddenFields from "./HiddenFields";
+import ManageColumns from "./ManageColumns";
 import RowHeight from "./RowHeight";
 
 import {
@@ -85,7 +86,8 @@ export default function TableToolbar() {
     >
       <AddRow />
       <div /> {/* Spacer */}
-      <HiddenFields />
+      {/* <HiddenFields /> */}
+      <ManageColumns />
       <Suspense fallback={<ButtonSkeleton />}>
         <Filters />
       </Suspense>

--- a/src/components/TableToolbar/TableToolbar.tsx
+++ b/src/components/TableToolbar/TableToolbar.tsx
@@ -14,7 +14,7 @@ import { ButtonSkeleton } from "./TableToolbarSkeleton";
 import AddRow from "./AddRow";
 import LoadedRowsStatus from "./LoadedRowsStatus";
 import TableSettings from "./TableSettings";
-import HiddenFields from "./HiddenFields";
+// import HiddenFields from "./HiddenFields";
 import ManageColumns from "./ManageColumns";
 import RowHeight from "./RowHeight";
 


### PR DESCRIPTION
[#562](https://github.com/rowyio/rowy/issues/562): Add accessible reorder option in column menu.

Worked on this improvement.

I started by creating a new file ManageColumns.tsx and keeping HiddenFields.tsx as the base.

I have used [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd) as recommended.
Dragging will be disabled when the search text field is not empty.

**Note**: HiddenFields.tsx is still there for reference.

![image](https://user-images.githubusercontent.com/62830866/203829717-59dbc0f6-9861-426e-b3fb-f6b06774abb4.png)
