### PR TITLE
null checking on .some functions

### DIFF
--- a/src/atoms/projectScope/project.ts
+++ b/src/atoms/projectScope/project.ts
@@ -48,7 +48,7 @@ export const tablesAtom = atom<TableSettings[]>((get) => {
   return sortBy(tables, "name")
     .filter((table) =>
       userRoles.includes("ADMIN") || Array.isArray(table.roles)
-        ? table.roles.some((role) => userRoles.includes(role))
+        ? table.roles?.some((role) => userRoles.includes(role))
         : false
     )
     .map((table) => ({

--- a/src/components/TableModals/ImportAirtableWizard/ImportAirtableWizard.tsx
+++ b/src/components/TableModals/ImportAirtableWizard/ImportAirtableWizard.tsx
@@ -72,7 +72,7 @@ export default function ImportAirtableWizard({ onClose }: ITableModalProps) {
       const newColumns = uniqBy(
         [...prev.newColumns, ...(value.newColumns ?? [])],
         "key"
-      ).filter((col) => pairs.some((pair) => pair.columnKey === col.key));
+      ).filter((col) => pairs?.some((pair) => pair.columnKey === col.key));
       return { ...prev, pairs, newColumns };
     });
   }, []);

--- a/src/components/TableModals/ImportCsvWizard/ImportCsvWizard.tsx
+++ b/src/components/TableModals/ImportCsvWizard/ImportCsvWizard.tsx
@@ -80,7 +80,7 @@ export default function ImportCsvWizard({ onClose }: ITableModalProps) {
       const newColumns = uniqBy(
         [...prev.newColumns, ...(value.newColumns ?? [])],
         "key"
-      ).filter((col) => pairs.some((pair) => pair.columnKey === col.key));
+      ).filter((col) => pairs?.some((pair) => pair.columnKey === col.key));
 
       return { ...prev, pairs, newColumns };
     });

--- a/src/components/TableTutorial/Steps/Step2Add.tsx
+++ b/src/components/TableTutorial/Steps/Step2Add.tsx
@@ -44,7 +44,7 @@ function StepComponent({ setComplete }: ITableTutorialStepComponentProps) {
   const [tableColumnsOrdered] = useAtom(tableColumnsOrderedAtom, tableScope);
   useEffect(() => {
     if (
-      tableColumnsOrdered.some(
+      tableColumnsOrdered?.some(
         (c) =>
           c.type === FieldType.rating && c.name.toLowerCase().includes("rating")
       )

--- a/src/components/fields/Connector/Select/PopupContents.tsx
+++ b/src/components/fields/Connector/Select/PopupContents.tsx
@@ -127,7 +127,9 @@ export default function PopupContents({
       <Grid item xs>
         <List sx={{ overflowY: "auto" }}>
           {hits.map((hit) => {
-            const isSelected = selectedValues.some((v) => v === hit[elementId]);
+            const isSelected = selectedValues?.some(
+              (v) => v === hit[elementId]
+            );
             return (
               <MenuItem
                 key={get(hit, elementId)}

--- a/src/hooks/useFirestoreDocWithAtom.ts
+++ b/src/hooks/useFirestoreDocWithAtom.ts
@@ -175,7 +175,7 @@ const getDocRef = <T>(
   path: string | undefined,
   pathSegments?: Array<string | undefined>
 ) => {
-  if (!path || (Array.isArray(pathSegments) && pathSegments.some((x) => !x)))
+  if (!path || (Array.isArray(pathSegments) && pathSegments?.some((x) => !x)))
     return null;
 
   return doc(

--- a/src/sources/ProjectSourceFirebase/useTableFunctions.ts
+++ b/src/sources/ProjectSourceFirebase/useTableFunctions.ts
@@ -84,7 +84,7 @@ export function useTableFunctions() {
             if (
               checked &&
               // Make sure we don’t have
-              !Object.values(columns).some((column) => column.type === type)
+              !Object.values(columns)?.some((column) => column.type === type)
             )
               columns["_" + camelCase(type)] = {
                 type,


### PR DESCRIPTION
As seen in https://github.com/rowyio/rowy/discussions/1037, some objects may be undefined before accessing .some function. This PR adds null checking for it in an attempt to resolve the issue.

Error stack for tracing id `ROWYERR-F917-CEEA-490C-78540106AD05`
_TypeError: Cannot read properties of undefined (reading 'some')\n    at https://rowy.app/static/js/main.3928d7f4.js:205:2244554\n    at Array.filter (<anonymous>)\n    at Object.read (https://rowy.app/static/js/main.3928d7f4.js:205:2244485)\n    at k (https://rowy.app/static/js/main.3928d7f4.js:205:2631450)\n    at Object.I [as r] (https://rowy.app/static/js/main.3928d7f4.js:205:2631763)\n    at s (https://rowy.app/static/js/main.3928d7f4.js:205:2635381)\n    at https://rowy.app/static/js/main.3928d7f4.js:205:2635585\n    at Object.Ca [as useReducer] (https://rowy.app/static/js/main.3928d7f4.js:205:1754814)\n    at t.useReducer (https://rowy.app/static/js/main.3928d7f4.js:205:1856923)\n    at x (https://rowy.app/static/js/main.3928d7f4.js:205:2635567)_