### PR TITLE
#ROWY-763: Import wizard select all

### DIFF
--- a/src/components/TableModals/ImportCsvWizard/Step1Columns.tsx
+++ b/src/components/TableModals/ImportCsvWizard/Step1Columns.tsx
@@ -68,7 +68,7 @@ export default function Step1Columns({
     if (selectedFields.length !== csvData.columns.length) {
       setSelectedFields(csvData.columns);
       csvData.columns.forEach(field => {
-        // Try to match the field to a column in the table
+        // Try to match each field to a column in the table
         const match =
           find(tableColumns, (column) =>
             column.label.toLowerCase().includes(field.toLowerCase())
@@ -89,34 +89,12 @@ export default function Step1Columns({
           ];
         }
         updateConfig(columnConfig);
-      }) 
-    } else {
-      setSelectedFields([]);
-      csvData.columns.forEach(field => {
-        // Check if this pair was already pushed to main config
-        const configPair = find(config.pairs, { csvKey: field });
-        const configIndex = findIndex(config.pairs, { csvKey: field });
-
-        // Delete matching newColumn if it was created
-        if (configPair) {
-          const newColumnIndex = findIndex(config.newColumns, {
-            key: configPair.columnKey,
-          });
-          if (newColumnIndex > -1) {
-            const newColumns = [...config.newColumns];
-            newColumns.splice(newColumnIndex, 1);
-            setConfig((config) => ({ ...config, newColumns }));
-          }
-        }
-
-        // Delete pair from main config
-        if (configIndex > -1) {
-          const newConfig = [...config.pairs];
-          newConfig.splice(configIndex, 1);
-          setConfig((config) => ({ ...config, pairs: newConfig }));
-        }
       })
-  }};
+    } else {
+      setSelectedFields([])
+      setConfig((config) => ({ ...config, newColumns: [], pairs: [] }))
+    }
+  };
 
   // When a field is selected to be imported
   const handleSelect =
@@ -241,36 +219,36 @@ export default function Step1Columns({
       <Divider />
 
       <FadeList>
-      <li>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={selectedFields.length === csvData.columns.length}
-                  indeterminate={
-                    selectedFields.length !== 0 &&
-                    selectedFields.length !== csvData.columns.length
-                  }
-                  onChange={handleSelectAll}
-                  color="default"
-                />
-              }
-              label="Select all"
-              sx={{
-                height: 42,
-                mr: 0,
-                alignItems: "center",
-                "& .MuiFormControlLabel-label": { mt: 0, flex: 1 },
-              }}
-            />
-          </li>
+        <li>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={selectedFields.length === csvData.columns.length}
+                indeterminate={
+                  selectedFields.length !== 0 &&
+                  selectedFields.length !== csvData.columns.length
+                }
+                onChange={handleSelectAll}
+                color="default"
+              />
+            }
+            label={selectedFields.length == csvData.columns.length ? "Clear all" : "Select all"}
+            sx={{
+              height: 42,
+              mr: 0,
+              alignItems: "center",
+              "& .MuiFormControlLabel-label": { mt: 0, flex: 1 },
+            }}
+          />
+        </li>
         {csvData.columns.map((field) => {
           const selected = selectedFields.indexOf(field) > -1;
           const columnKey =
             find(config.pairs, { csvKey: field })?.columnKey ?? null;
           const matchingColumn = columnKey
             ? tableSchema.columns?.[columnKey] ??
-              find(config.newColumns, { key: columnKey }) ??
-              null
+            find(config.newColumns, { key: columnKey }) ??
+            null
             : null;
           const isNewColumn = !!find(config.newColumns, { key: columnKey });
 

--- a/src/components/TableModals/ImportExistingWizard/Step1Columns.tsx
+++ b/src/components/TableModals/ImportExistingWizard/Step1Columns.tsx
@@ -117,7 +117,7 @@ export default function Step1Columns({ config, setConfig }: IStepProps) {
                   color="default"
                 />
               }
-              label="Select all"
+              label={selectedFields.length == allFields.length ? "Clear all" : "Select all"}
               sx={{
                 height: 42,
                 mr: 0,


### PR DESCRIPTION
This PR adds a "select all" option to the CSV and Airtable import wizards, allowing users to select all columns or fields of their Airtable or CSV tables to import at once.