### PR TITLE
ROWY-912: allow multiple params for logging

### DIFF
--- a/src/components/CodeEditor/rowy.d.ts
+++ b/src/components/CodeEditor/rowy.d.ts
@@ -18,9 +18,9 @@ type uploadOptions = {
   fileName?: string;
 };
 type RowyLogging = {
-  log: (payload: any) => void;
-  warn: (payload: any) => void;
-  error: (payload: any) => void;
+  log: (...payload: any[]) => void;
+  warn: (...payload: any[]) => void;
+  error: (...payload: any[]) => void;
 };
 interface Rowy {
   metadata: {


### PR DESCRIPTION
Allows Rowy Logging to accept multiple parameters just like console.log

If 1 item is passed in to `logging.log`, it will be displayed the same way as before. If more than 1 items are passed in, an array will be displayed in Rowy Logging.
E.g. `logging.log("error", e.message)`
<img width="949" alt="Screenshot 2023-02-23 at 13 45 10" src="https://user-images.githubusercontent.com/34177142/220838781-dfd5dddf-441c-46bb-beab-d96ca7295558.png">


Backend PRs:
- https://github.com/rowyio/backend/pull/28/
- https://github.com/rowyio/rowy-hooks/pull/4