### PR TITLE
fix export crash due to toDate issue

### DIFF
--- a/src/components/fields/Date/index.tsx
+++ b/src/components/fields/Date/index.tsx
@@ -35,8 +35,13 @@ export const config: IFieldConfig = {
   filter: { operators: filterOperators, valueFormatter },
   settings: Settings,
   csvImportParser: (value, config) => parse(value, DATE_FORMAT, new Date()),
-  csvExportFormatter: (value: any, config?: any) =>
-    format(value.toDate(), DATE_FORMAT),
+  csvExportFormatter: (value: any, config?: any) => {
+    if (typeof value === "number") {
+      return format(new Date(value), DATE_FORMAT);
+    } else {
+      return format(value.toDate(), DATE_FORMAT);
+    }
+  },
 };
 export default config;
 

--- a/src/components/fields/DateTime/index.tsx
+++ b/src/components/fields/DateTime/index.tsx
@@ -49,9 +49,9 @@ export const config: IFieldConfig = {
   csvImportParser: (value) => new Date(value),
   csvExportFormatter: (value: any, config?: any) => {
     if (typeof value === "number") {
-      return format(new Date(value), config?.format || DATE_TIME_FORMAT);
+      return format(new Date(value), DATE_TIME_FORMAT);
     } else {
-      return format(value.toDate(), config?.format || DATE_TIME_FORMAT);
+      return format(value.toDate(), DATE_TIME_FORMAT);
     }
   },
 };

--- a/src/components/fields/DateTime/index.tsx
+++ b/src/components/fields/DateTime/index.tsx
@@ -47,8 +47,13 @@ export const config: IFieldConfig = {
   },
   settings: Settings,
   csvImportParser: (value) => new Date(value),
-  csvExportFormatter: (value: any, config?: any) =>
-    format(value.toDate(), DATE_TIME_FORMAT),
+  csvExportFormatter: (value: any, config?: any) => {
+    if (typeof value === "number") {
+      return format(new Date(value), config?.format || DATE_TIME_FORMAT);
+    } else {
+      return format(value.toDate(), config?.format || DATE_TIME_FORMAT);
+    }
+  },
 };
 export default config;
 


### PR DESCRIPTION
If date/datetime is a number, it will not have `toDate` thus causing export to crash. Easy fix by adding the handler for this case.

<img width="893" alt="Screenshot 2023-04-01 at 02 48 42" src="https://user-images.githubusercontent.com/34177142/229138138-288bccfa-6605-4616-a711-299f2fcbafe7.png">
