### PR TITLE
Expand support for fields that can be copied to clipboard

### DIFF
--- a/src/components/Table/ContextMenu/BasicCellContextMenuActions.tsx
+++ b/src/components/Table/ContextMenu/BasicCellContextMenuActions.tsx
@@ -3,12 +3,19 @@ import { Copy as CopyCells } from "@src/assets/icons";
 import Paste from "@mui/icons-material/ContentPaste";
 import { IFieldConfig } from "@src/components/fields/types";
 import { useMenuAction } from "@src/components/Table/useMenuAction";
+import { useAtom } from "jotai";
+import { tableSchemaAtom, tableScope } from "@src/atoms/tableScope";
+
+import { SUPPORTED_TYPES_PASTE } from "@src/components/Table/useMenuAction";
 
 // TODO: Remove this and add `handlePaste` function to column config
 export const BasicContextMenuActions: IFieldConfig["contextMenuActions"] = (
   selectedCell,
   reset
 ) => {
+  const [tableSchema] = useAtom(tableSchemaAtom, tableScope);
+  const selectedCol = tableSchema.columns?.[selectedCell.columnKey];
+
   const handleClose = async () => await reset?.();
   const { handleCopy, handlePaste, cellValue } = useMenuAction(
     selectedCell,
@@ -24,8 +31,16 @@ export const BasicContextMenuActions: IFieldConfig["contextMenuActions"] = (
       disabled:
         cellValue === undefined || cellValue === null || cellValue === "",
     },
-    { label: "Paste", icon: <Paste />, onClick: handlePaste },
   ];
+
+  if (SUPPORTED_TYPES_PASTE.has(selectedCol?.type)) {
+    contextMenuActions.push({
+      label: "Paste",
+      icon: <Paste />,
+      onClick: handlePaste,
+      disabled: false,
+    });
+  }
 
   return contextMenuActions;
 };

--- a/src/components/fields/Array/index.tsx
+++ b/src/components/fields/Array/index.tsx
@@ -6,6 +6,8 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import DisplayCell from "./DisplayCell";
 
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
+
 const SideDrawerField = lazy(
   () =>
     import("./SideDrawerField" /* webpackChunkName: "SideDrawerField-Array" */)
@@ -26,5 +28,6 @@ export const config: IFieldConfig = {
   }),
   SideDrawerField,
   requireConfiguration: false,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/Checkbox/index.tsx
+++ b/src/components/fields/Checkbox/index.tsx
@@ -5,6 +5,8 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 import CheckboxIcon from "@mui/icons-material/ToggleOnOutlined";
 import DisplayCell from "./DisplayCell";
 
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
+
 const EditorCell = lazy(
   () => import("./EditorCell" /* webpackChunkName: "EditorCell-Checkbox" */)
 );
@@ -42,5 +44,6 @@ export const config: IFieldConfig = {
     defaultValue: false,
   },
   SideDrawerField,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/Code/index.tsx
+++ b/src/components/fields/Code/index.tsx
@@ -5,6 +5,8 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 import CodeIcon from "@mui/icons-material/Code";
 import DisplayCell from "./DisplayCell";
 
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
+
 const Settings = lazy(
   () => import("./Settings" /* webpackChunkName: "Settings-Code" */)
 );
@@ -31,5 +33,6 @@ export const config: IFieldConfig = {
   }),
   SideDrawerField,
   settings: Settings,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/Color/index.tsx
+++ b/src/components/fields/Color/index.tsx
@@ -7,6 +7,8 @@ import ColorIcon from "@mui/icons-material/Colorize";
 import DisplayCell from "./DisplayCell";
 import { filterOperators, valueFormatter } from "./filters";
 
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
+
 const EditorCell = lazy(
   () => import("./EditorCell" /* webpackChunkName: "EditorCell-Color" */)
 );
@@ -41,5 +43,6 @@ export const config: IFieldConfig = {
       return null;
     }
   },
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/CreatedAt/index.tsx
+++ b/src/components/fields/CreatedAt/index.tsx
@@ -4,6 +4,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import { CreatedAt as CreatedAtIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -28,5 +29,6 @@ export const config: IFieldConfig = {
   SideDrawerField,
   settings: Settings,
   requireCollectionTable: true,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/CreatedBy/index.tsx
+++ b/src/components/fields/CreatedBy/index.tsx
@@ -4,6 +4,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import { CreatedBy as CreatedByIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -29,5 +30,6 @@ export const config: IFieldConfig = {
   SideDrawerField,
   settings: Settings,
   requireCollectionTable: true,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/Date/index.tsx
+++ b/src/components/fields/Date/index.tsx
@@ -7,6 +7,7 @@ import { DATE_FORMAT } from "@src/constants/dates";
 import DateIcon from "@mui/icons-material/TodayOutlined";
 import DisplayCell from "./DisplayCell";
 import { filterOperators, valueFormatter } from "./filters";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const EditorCell = lazy(
   () => import("./EditorCell" /* webpackChunkName: "EditorCell-Date" */)
@@ -42,6 +43,7 @@ export const config: IFieldConfig = {
       return format(value.toDate(), DATE_FORMAT);
     }
   },
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;
 

--- a/src/components/fields/DateTime/index.tsx
+++ b/src/components/fields/DateTime/index.tsx
@@ -7,6 +7,7 @@ import { DATE_TIME_FORMAT } from "@src/constants/dates";
 import DateTimeIcon from "@mui/icons-material/AccessTime";
 import DisplayCell from "./DisplayCell";
 import { filterOperators, valueFormatter } from "./filters";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const EditorCell = lazy(
   () => import("./EditorCell" /* webpackChunkName: "EditorCell-DateTime" */)
@@ -54,6 +55,7 @@ export const config: IFieldConfig = {
       return format(value.toDate(), DATE_TIME_FORMAT);
     }
   },
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;
 

--- a/src/components/fields/Duration/index.tsx
+++ b/src/components/fields/Duration/index.tsx
@@ -4,6 +4,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import DurationIcon from "@mui/icons-material/TimerOutlined";
 import DisplayCell from "./DisplayCell";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -24,5 +25,6 @@ export const config: IFieldConfig = {
     popoverProps: { PaperProps: { sx: { p: 1 } } },
   }),
   SideDrawerField,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/File/ContextMenuActions.tsx
+++ b/src/components/fields/File/ContextMenuActions.tsx
@@ -1,0 +1,83 @@
+import { useAtom } from "jotai";
+import { find, get } from "lodash-es";
+import { useSnackbar } from "notistack";
+
+import OpenIcon from "@mui/icons-material/OpenInNewOutlined";
+import { Copy } from "@src/assets/icons";
+import { FileIcon } from ".";
+
+import {
+  tableScope,
+  tableSchemaAtom,
+  tableRowsAtom,
+} from "@src/atoms/tableScope";
+import { IFieldConfig } from "@src/components/fields/types";
+
+export interface IContextMenuActions {
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+}
+
+export const ContextMenuActions: IFieldConfig["contextMenuActions"] = (
+  selectedCell,
+  reset
+) => {
+  const [tableSchema] = useAtom(tableSchemaAtom, tableScope);
+  const [tableRows] = useAtom(tableRowsAtom, tableScope);
+  const { enqueueSnackbar } = useSnackbar();
+
+  const selectedCol = tableSchema.columns?.[selectedCell.columnKey];
+  if (!selectedCol) return [];
+
+  const selectedRow = find(tableRows, ["_rowy_ref.path", selectedCell.path]);
+  const cellValue = get(selectedRow, selectedCol.fieldName) || [];
+
+  const isEmpty =
+    cellValue === "" ||
+    cellValue === null ||
+    cellValue === undefined ||
+    cellValue.length === 0;
+  const isSingleValue = isEmpty || cellValue?.length === 1;
+
+  const handleCopyFileURL = (fileObj: RowyFile) => () => {
+    navigator.clipboard.writeText(fileObj.downloadURL);
+    enqueueSnackbar("Copied file URL");
+    reset();
+  };
+  const handleViewFile = (fileObj: RowyFile) => () => {
+    window.open(fileObj.downloadURL, "_blank");
+    reset();
+  };
+
+  return [
+    {
+      label: "Copy file URL",
+      icon: <Copy />,
+      onClick: isSingleValue ? handleCopyFileURL(cellValue[0]) : undefined,
+      disabled: isEmpty,
+      subItems: isSingleValue
+        ? []
+        : cellValue.map((fileObj: RowyFile, index: number) => ({
+            label: fileObj.name || "File " + (index + 1),
+            icon: <FileIcon />,
+            onClick: handleCopyFileURL(fileObj),
+          })),
+    },
+    {
+      label: "View file",
+      icon: <OpenIcon />,
+      onClick: isSingleValue ? handleViewFile(cellValue[0]) : undefined,
+      disabled: isEmpty,
+      subItems: isSingleValue
+        ? []
+        : cellValue.map((fileObj: RowyFile, index: number) => ({
+            label: fileObj.name || "File " + (index + 1),
+            icon: <FileIcon />,
+            onClick: handleViewFile(fileObj),
+          })),
+    },
+  ];
+};
+
+export default ContextMenuActions;

--- a/src/components/fields/File/index.tsx
+++ b/src/components/fields/File/index.tsx
@@ -4,6 +4,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import FileIcon from "@mui/icons-material/AttachFile";
 import DisplayCell from "./DisplayCell";
+import ContextMenuActions from "./ContextMenuActions";
 
 const EditorCell = lazy(
   () => import("./EditorCell" /* webpackChunkName: "EditorCell-File" */)
@@ -26,6 +27,7 @@ export const config: IFieldConfig = {
     disablePadding: true,
   }),
   SideDrawerField,
+  contextMenuActions: ContextMenuActions,
 };
 export default config;
 

--- a/src/components/fields/GeoPoint/index.tsx
+++ b/src/components/fields/GeoPoint/index.tsx
@@ -4,6 +4,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import GeoPointIcon from "@mui/icons-material/PinDropOutlined";
 import DisplayCell from "./DisplayCell";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -24,5 +25,6 @@ export const config: IFieldConfig = {
     popoverProps: { PaperProps: { sx: { p: 1, pt: 0 } } },
   }),
   SideDrawerField,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/Markdown/index.tsx
+++ b/src/components/fields/Markdown/index.tsx
@@ -4,6 +4,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import { Markdown as MarkdownIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -23,5 +24,6 @@ export const config: IFieldConfig = {
   description: "Markdown editor with preview",
   TableCell: withRenderTableCell(DisplayCell, SideDrawerField, "popover"),
   SideDrawerField,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/MultiSelect/index.tsx
+++ b/src/components/fields/MultiSelect/index.tsx
@@ -5,6 +5,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 import { MultiSelect as MultiSelectIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
 import { filterOperators } from "./Filter";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const EditorCell = lazy(
   () => import("./EditorCell" /* webpackChunkName: "EditorCell-MultiSelect" */)
@@ -48,5 +49,6 @@ export const config: IFieldConfig = {
   filter: {
     operators: filterOperators,
   },
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/Rating/index.tsx
+++ b/src/components/fields/Rating/index.tsx
@@ -6,6 +6,7 @@ import RatingIcon from "@mui/icons-material/StarBorder";
 import DisplayCell from "./DisplayCell";
 import EditorCell from "./EditorCell";
 import { filterOperators } from "@src/components/fields/Number/Filter";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -44,5 +45,6 @@ export const config: IFieldConfig = {
       return null;
     }
   },
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/SingleSelect/index.tsx
+++ b/src/components/fields/SingleSelect/index.tsx
@@ -6,6 +6,7 @@ import { SingleSelect as SingleSelectIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
 import EditorCell from "./EditorCell";
 import { filterOperators } from "@src/components/fields/ShortText/Filter";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -35,5 +36,6 @@ export const config: IFieldConfig = {
   settings: Settings,
   filter: { operators: filterOperators },
   requireConfiguration: true,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/Slider/index.tsx
+++ b/src/components/fields/Slider/index.tsx
@@ -5,6 +5,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 import { Slider as SliderIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
 import { filterOperators } from "@src/components/fields/Number/Filter";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -44,5 +45,6 @@ export const config: IFieldConfig = {
       return null;
     }
   },
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/UpdatedAt/index.tsx
+++ b/src/components/fields/UpdatedAt/index.tsx
@@ -4,6 +4,7 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 
 import { UpdatedAt as UpdatedAtIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
 
 const SideDrawerField = lazy(
   () =>
@@ -29,5 +30,6 @@ export const config: IFieldConfig = {
   SideDrawerField,
   settings: Settings,
   requireCollectionTable: true,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;

--- a/src/components/fields/UpdatedBy/index.tsx
+++ b/src/components/fields/UpdatedBy/index.tsx
@@ -5,6 +5,8 @@ import withRenderTableCell from "@src/components/Table/TableCell/withRenderTable
 import { UpdatedBy as UpdatedByIcon } from "@src/assets/icons";
 import DisplayCell from "./DisplayCell";
 
+import BasicContextMenuActions from "@src/components/Table/ContextMenu/BasicCellContextMenuActions";
+
 const SideDrawerField = lazy(
   () =>
     import(
@@ -30,5 +32,6 @@ export const config: IFieldConfig = {
   SideDrawerField,
   settings: Settings,
   requireCollectionTable: true,
+  contextMenuActions: BasicContextMenuActions,
 };
 export default config;


### PR DESCRIPTION
This change resolves the issue #1154.
Furthermore, the update includes a new functionality that limits the fields where values can be pasted using the hotkey. Prior to this update, the hotkey allowed for the pasting of values in any field type, including read-only fields like CreatedBy, CreatedAt. This created the possibility for data corruption, as read-only fields could be modified. The new feature prevents such accidental modifications by restricting the fields where the hotkey can be used, ensuring that read-only fields remain unmodifiable.