### PR TITLE
Fix Safari turning decimal number inputs to 0

### DIFF
--- a/src/components/Table/TableCell/EditorCellTextField.tsx
+++ b/src/components/Table/TableCell/EditorCellTextField.tsx
@@ -4,6 +4,7 @@ import { spreadSx } from "@src/utils/ui";
 
 export interface IEditorCellTextFieldProps extends IEditorCellProps<string> {
   InputProps?: Partial<InputBaseProps>;
+  onBlur?: () => void;
 }
 
 export default function EditorCellTextField({
@@ -11,6 +12,7 @@ export default function EditorCellTextField({
   value,
   onDirty,
   onChange,
+  onBlur,
   setFocusInsideCell,
   InputProps = {},
 }: IEditorCellTextFieldProps) {
@@ -19,7 +21,12 @@ export default function EditorCellTextField({
   return (
     <InputBase
       value={value}
-      onBlur={() => onDirty()}
+      onBlur={() => {
+        if (onBlur) {
+          onBlur();
+        }
+        onDirty();
+      }}
       onChange={(e) => onChange(e.target.value)}
       fullWidth
       autoFocus
@@ -42,6 +49,11 @@ export default function EditorCellTextField({
           setTimeout(() => setFocusInsideCell(false));
         }
         if (e.key === "Enter" && !e.shiftKey) {
+          // Trigger an onBlur in case we have any final mutations
+          if (onBlur) {
+            onBlur();
+          }
+
           // Removes focus from inside cell, triggering save on unmount
           setFocusInsideCell(false);
         }

--- a/src/components/fields/Number/EditorCell.tsx
+++ b/src/components/fields/Number/EditorCell.tsx
@@ -13,6 +13,11 @@ export default function Number_(props: IEditorCellProps<number | string>) {
         const parsedValue = v === "" ? v : Number(v);
         props.onChange(parsedValue);
       }}
+      onBlur={() => {
+        // Cast to number when the user has finished editing
+        props.onChange(Number(props.value));
+        props.onDirty();
+      }}
     />
   );
 }

--- a/src/components/fields/Number/EditorCell.tsx
+++ b/src/components/fields/Number/EditorCell.tsx
@@ -3,10 +3,6 @@ import EditorCellTextField from "@src/components/Table/TableCell/EditorCellTextF
 
 export default function Number_(props: IEditorCellProps<number>) {
   return (
-    <EditorCellTextField
-      {...(props as any)}
-      InputProps={{ type: "number" }}
-      onChange={(v) => props.onChange(Number(v))}
-    />
+    <EditorCellTextField {...(props as any)} InputProps={{ type: "number" }} />
   );
 }

--- a/src/components/fields/Number/EditorCell.tsx
+++ b/src/components/fields/Number/EditorCell.tsx
@@ -1,8 +1,18 @@
 import type { IEditorCellProps } from "@src/components/fields/types";
 import EditorCellTextField from "@src/components/Table/TableCell/EditorCellTextField";
 
-export default function Number_(props: IEditorCellProps<number>) {
+export default function Number_(props: IEditorCellProps<number | string>) {
   return (
-    <EditorCellTextField {...(props as any)} InputProps={{ type: "number" }} />
+    <EditorCellTextField
+      {...(props as any)}
+      InputProps={{ type: "number" }}
+      onChange={(v) => {
+        // Safari/Firefox gives us an empty string for invalid inputs, which includes inputs like "12." on the way to
+        // typing "12.34". Number would cast these to 0 and replace the user's input to 0 whilst they're mid-way through
+        // typing. We want to avoid that.
+        const parsedValue = v === "" ? v : Number(v);
+        props.onChange(parsedValue);
+      }}
+    />
   );
 }

--- a/src/components/fields/Number/SideDrawerField.tsx
+++ b/src/components/fields/Number/SideDrawerField.tsx
@@ -23,7 +23,11 @@ export default function Number_({
           e.target.value === "" ? e.target.value : Number(e.target.value);
         onChange(parsedValue);
       }}
-      onBlur={onSubmit}
+      onBlur={() => {
+        // Cast to number when the user has finished editing
+        onChange(Number(value));
+        onSubmit();
+      }}
       value={value}
       id={getFieldId(column.key)}
       label=""

--- a/src/components/fields/Number/SideDrawerField.tsx
+++ b/src/components/fields/Number/SideDrawerField.tsx
@@ -9,13 +9,20 @@ export default function Number_({
   onChange,
   onSubmit,
   disabled,
-}: ISideDrawerFieldProps) {
+}: ISideDrawerFieldProps<number | string>) {
   return (
     <TextField
       variant="filled"
       fullWidth
       margin="none"
-      onChange={(e) => onChange(Number(e.target.value))}
+      onChange={(e) => {
+        // Safari/Firefox gives us an empty string for invalid inputs, which includes inputs like "12." on the way to
+        // typing "12.34". Number would cast these to 0 and replace the user's input to 0 whilst they're mid-way through
+        // typing. We want to avoid that.
+        const parsedValue =
+          e.target.value === "" ? e.target.value : Number(e.target.value);
+        onChange(parsedValue);
+      }}
       onBlur={onSubmit}
       value={value}
       id={getFieldId(column.key)}

--- a/src/components/fields/Percentage/EditorCell.tsx
+++ b/src/components/fields/Percentage/EditorCell.tsx
@@ -2,7 +2,7 @@ import type { IEditorCellProps } from "@src/components/fields/types";
 import EditorCellTextField from "@src/components/Table/TableCell/EditorCellTextField";
 import { multiply100WithPrecision, divide100WithPrecision } from "./utils";
 
-export default function Percentage(props: IEditorCellProps<number>) {
+export default function Percentage(props: IEditorCellProps<number | string>) {
   return (
     <EditorCellTextField
       {...(props as any)}
@@ -13,7 +13,16 @@ export default function Percentage(props: IEditorCellProps<number>) {
           : props.value
       }
       onChange={(v) => {
-        props.onChange(divide100WithPrecision(Number(v)));
+        // Safari/Firefox gives us an empty string for invalid inputs, which includes inputs like "12." on the way to
+        // typing "12.34". Number would cast these to 0 and replace the user's input to 0 whilst they're mid-way through
+        // typing. We want to avoid that.
+        const parsedValue = v === "" ? v : divide100WithPrecision(Number(v));
+        props.onChange(parsedValue);
+      }}
+      onBlur={() => {
+        // Cast to number when the user has finished editing
+        props.onChange(Number(props.value));
+        props.onDirty();
       }}
     />
   );

--- a/src/components/fields/Percentage/SideDrawerField.tsx
+++ b/src/components/fields/Percentage/SideDrawerField.tsx
@@ -11,7 +11,7 @@ export default function Percentage({
   onChange,
   onSubmit,
   disabled,
-}: ISideDrawerFieldProps) {
+}: ISideDrawerFieldProps<number | string>) {
   const { colors } = (column as any).config;
   const theme = useTheme();
   return (
@@ -19,8 +19,19 @@ export default function Percentage({
       variant="filled"
       fullWidth
       margin="none"
-      onChange={(e) => onChange(Number(e.target.value) / 100)}
-      onBlur={onSubmit}
+      onChange={(e) => {
+        // Safari/Firefox gives us an empty string for invalid inputs, which includes inputs like "12." on the way to
+        // typing "12.34". Number would cast these to 0 and replace the user's input to 0 whilst they're mid-way through
+        // typing. We want to avoid that.
+        const parsedValue =
+          e.target.value === "" ? e.target.value : Number(e.target.value) / 100;
+        onChange(parsedValue);
+      }}
+      onBlur={() => {
+        // Cast to number when the user has finished editing
+        onChange(Number(value));
+        onSubmit();
+      }}
       value={
         typeof value === "number" ? multiply100WithPrecision(value) : value
       }

--- a/src/components/fields/types.ts
+++ b/src/components/fields/types.ts
@@ -86,7 +86,7 @@ export interface ISideDrawerFieldProps<T = any> {
   /** Call when the user has input but changes have not been saved */
   onDirty: (dirty?: boolean) => void;
   /** Update the local value. Also calls onDirty */
-  onChange: (T: any) => void;
+  onChange: (value: T) => void;
   /** Call when user input is ready to be saved (e.g. onBlur) */
   onSubmit: () => void;
 


### PR DESCRIPTION
Chrome has some slightly unique input[type="number"] handling behaviour, where it restricts the characters that can be typed to numeric characters. Under-the-hood, Chrome withholds certain invalid input states from being emitted as change events – so we only receive change events for valid numbers.

Safari behaves slightly differently. It allows any characters to be entered and emits a change event on each character press, but its internal "value" is only set if the typed input is a valid number. The change events then either come through with a numeric value represented, or as an empty string.

For example, when typing "12.34" we receive onChange events with "1", "12", "", "12.3", and "12.34".

On that third onChange event when we pass "" up to React, React happily ignores the change (I _think_ bceause the incoming value "" already matches the element's value of ""; nonetheless, React have solved this issue for us).

When we parse the input via `Number(v)` we encounter problems. `Number("")` resolves to `0`, React sets the input's value to `0`, and the user is therefore unable to type decimal values successfully.

The solution for this is not to cast to a number at all. We'll rely on default browser behaviour to manage the input for us (allowing users to enter invalid characters), but we're still safe because the element's internal state will always be numeric.

In the scenario that a customer does try enter an invalid input "abc123", the input field simply blanks itself when they leave it.

/claim #1181