### PR TITLE
add support for bulk deletion of rows

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -276,11 +276,13 @@ export default function Table({
 
       updateColumn({
         key: result.draggableId,
-        index: result.destination.index,
+        index: selectedRows
+          ? result.destination.index - 1
+          : result.destination.index,
         config: {},
       });
     },
-    [updateColumn]
+    [updateColumn, selectedRows]
   );
 
   const fetchMoreOnBottomReached = useThrottledCallback(

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -204,14 +204,16 @@ export default function Table({
     return hiddenColumns.reduce((a, c) => ({ ...a, [c]: false }), {});
   }, [hiddenColumns]);
 
-  // Get frozen columns and memoize into a `ColumnPinningState`
   const columnPinning: ColumnPinningState = useMemo(
     () => ({
-      left: columns
-        .filter(
-          (c) => c.meta?.fixed && c.id && columnVisibility[c.id] !== false
-        )
-        .map((c) => c.id!),
+      left: [
+        ...(selectedRows ? ["_rowy_select"] : []),
+        ...columns
+          .filter(
+            (c) => c.meta?.fixed && c.id && columnVisibility[c.id] !== false
+          )
+          .map((c) => c.id!),
+      ],
     }),
     [columns, columnVisibility]
   );

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -353,7 +353,7 @@ export default function Table({
           }}
         >
           <TableHeader
-            table={table}
+            headerGroups={table.getHeaderGroups()}
             handleDropColumn={handleDropColumn}
             canAddColumns={canAddColumns}
             canEditColumns={canEditColumns}

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -54,7 +54,7 @@ export interface ITableBodyProps {
  * - Renders row out of order indicator
  * - Renders next page loading UI (`RowsSkeleton`)
  */
-export const TableBody = function TableBody({
+export const TableBody = memo(function TableBody({
   containerRef,
   leafColumns,
   rows,
@@ -157,6 +157,6 @@ export const TableBody = function TableBody({
       )}
     </div>
   );
-};
+});
 
 export default TableBody;

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -1,6 +1,11 @@
 import { memo } from "react";
 import { useAtom } from "jotai";
-import type { Column, Row, ColumnSizingState } from "@tanstack/react-table";
+import {
+  Column,
+  Row,
+  ColumnSizingState,
+  flexRender,
+} from "@tanstack/react-table";
 
 import StyledRow from "./Styled/StyledRow";
 import OutOfOrderIndicator from "./OutOfOrderIndicator";
@@ -18,6 +23,7 @@ import { getFieldProp } from "@src/components/fields";
 import type { TableRow } from "@src/types/table";
 import useVirtualization from "./useVirtualization";
 import { DEFAULT_ROW_HEIGHT, OUT_OF_ORDER_MARGIN } from "./Table";
+import StyledCell from "./Styled/StyledCell";
 
 export interface ITableBodyProps {
   /**
@@ -48,7 +54,7 @@ export interface ITableBodyProps {
  * - Renders row out of order indicator
  * - Renders next page loading UI (`RowsSkeleton`)
  */
-export const TableBody = memo(function TableBody({
+export const TableBody = function TableBody({
   containerRef,
   leafColumns,
   rows,
@@ -114,6 +120,14 @@ export const TableBody = memo(function TableBody({
               const isReadOnlyCell =
                 fieldTypeGroup === "Auditing" || fieldTypeGroup === "Metadata";
 
+              if (cell.id.includes("_rowy_select")) {
+                return (
+                  <StyledCell key={cell.id} role="gridcell">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </StyledCell>
+                );
+              }
+
               return (
                 <TableCell
                   key={cell.id}
@@ -143,6 +157,6 @@ export const TableBody = memo(function TableBody({
       )}
     </div>
   );
-});
+};
 
 export default TableBody;

--- a/src/components/Table/TableHeader.tsx
+++ b/src/components/Table/TableHeader.tsx
@@ -2,7 +2,11 @@ import { memo, Fragment } from "react";
 import { useAtom } from "jotai";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import type { DropResult } from "react-beautiful-dnd";
-import { ColumnSizingState, Table, flexRender } from "@tanstack/react-table";
+import {
+  ColumnSizingState,
+  HeaderGroup,
+  flexRender,
+} from "@tanstack/react-table";
 import type { TableRow } from "@src/types/table";
 
 import StyledRow from "./Styled/StyledRow";
@@ -15,7 +19,7 @@ import StyledColumnHeader from "./Styled/StyledColumnHeader";
 
 export interface ITableHeaderProps {
   /** Headers with context from TanStack Table state */
-  table: Table<TableRow>;
+  headerGroups: HeaderGroup<TableRow>[];
   /** Called when a header is dropped in a new position */
   handleDropColumn: (result: DropResult) => void;
   /** Passed to `FinalColumnHeader` */
@@ -35,14 +39,13 @@ export interface ITableHeaderProps {
  *
  * - Renders drag & drop components
  */
-export const TableHeader = function TableHeader({
-  table,
+export const TableHeader = memo(function TableHeader({
+  headerGroups,
   handleDropColumn,
   canAddColumns,
   canEditColumns,
   lastFrozen,
 }: ITableHeaderProps) {
-  const headerGroups = table.getHeaderGroups();
   const [selectedCell] = useAtom(selectedCellAtom, tableScope);
   const focusInside = selectedCell?.focusInside ?? false;
 
@@ -145,6 +148,6 @@ export const TableHeader = function TableHeader({
       ))}
     </DragDropContext>
   );
-};
+});
 
 export default TableHeader;

--- a/src/components/Table/TableHeader.tsx
+++ b/src/components/Table/TableHeader.tsx
@@ -2,7 +2,7 @@ import { memo, Fragment } from "react";
 import { useAtom } from "jotai";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import type { DropResult } from "react-beautiful-dnd";
-import type { ColumnSizingState, HeaderGroup } from "@tanstack/react-table";
+import { ColumnSizingState, Table, flexRender } from "@tanstack/react-table";
 import type { TableRow } from "@src/types/table";
 
 import StyledRow from "./Styled/StyledRow";
@@ -11,10 +11,11 @@ import FinalColumnHeader from "./FinalColumn/FinalColumnHeader";
 
 import { tableScope, selectedCellAtom } from "@src/atoms/tableScope";
 import { DEFAULT_ROW_HEIGHT } from "@src/components/Table";
+import StyledColumnHeader from "./Styled/StyledColumnHeader";
 
 export interface ITableHeaderProps {
   /** Headers with context from TanStack Table state */
-  headerGroups: HeaderGroup<TableRow>[];
+  table: Table<TableRow>;
   /** Called when a header is dropped in a new position */
   handleDropColumn: (result: DropResult) => void;
   /** Passed to `FinalColumnHeader` */
@@ -34,13 +35,14 @@ export interface ITableHeaderProps {
  *
  * - Renders drag & drop components
  */
-export const TableHeader = memo(function TableHeader({
-  headerGroups,
+export const TableHeader = function TableHeader({
+  table,
   handleDropColumn,
   canAddColumns,
   canEditColumns,
   lastFrozen,
 }: ITableHeaderProps) {
+  const headerGroups = table.getHeaderGroups();
   const [selectedCell] = useAtom(selectedCellAtom, tableScope);
   const focusInside = selectedCell?.focusInside ?? false;
 
@@ -68,6 +70,20 @@ export const TableHeader = memo(function TableHeader({
                     selectedCell?.columnKey === header.id);
 
                 const isLastHeader = i === headerGroup.headers.length - 1;
+
+                if (header.id === "_rowy_select")
+                  return (
+                    <StyledColumnHeader
+                      key={header.id}
+                      role="columnheader"
+                      style={{ padding: 0 }}
+                    >
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                    </StyledColumnHeader>
+                  );
 
                 // Render later, after the drag & drop placeholder
                 if (header.id === "_rowy_column_actions")
@@ -129,6 +145,6 @@ export const TableHeader = memo(function TableHeader({
       ))}
     </DragDropContext>
   );
-});
+};
 
 export default TableHeader;

--- a/src/components/Table/useVirtualization.tsx
+++ b/src/components/Table/useVirtualization.tsx
@@ -71,7 +71,8 @@ export function useVirtualization(
         const definedWidth = localWidth || schemaWidth;
 
         if (definedWidth === undefined) return DEFAULT_COL_WIDTH;
-        if (definedWidth < MIN_COL_WIDTH) return MIN_COL_WIDTH;
+        if (definedWidth < MIN_COL_WIDTH && columnDef.id !== "_rowy_select")
+          return MIN_COL_WIDTH;
         return definedWidth;
       },
       [leafColumns, columnSizing]

--- a/src/pages/Table/ProvidedArraySubTablePage.tsx
+++ b/src/pages/Table/ProvidedArraySubTablePage.tsx
@@ -139,6 +139,7 @@ export default function ProvidedArraySubTablePage() {
             <DebugAtoms scope={tableScope} />
             <ArraySubTableSourceFirestore />
             <TablePage
+              enableRowSelection={false}
               disabledTools={[
                 "import",
                 "export",

--- a/src/pages/Table/ProvidedSubTablePage.tsx
+++ b/src/pages/Table/ProvidedSubTablePage.tsx
@@ -137,7 +137,7 @@ export default function ProvidedSubTablePage() {
           >
             <DebugAtoms scope={tableScope} />
             <TableSourceFirestore />
-            <TablePage />
+            <TablePage enableRowSelection />
           </Provider>
         </Suspense>
       </ErrorBoundary>

--- a/src/pages/Table/ProvidedTablePage.tsx
+++ b/src/pages/Table/ProvidedTablePage.tsx
@@ -141,7 +141,7 @@ export default function ProvidedTablePage() {
             }
           >
             <main>
-              <TablePage disableModals={Boolean(outlet)} />
+              <TablePage enableRowSelection disableModals={Boolean(outlet)} />
             </main>
           </Suspense>
           <Suspense fallback={null}>{outlet}</Suspense>

--- a/src/pages/Table/TablePage.tsx
+++ b/src/pages/Table/TablePage.tsx
@@ -57,6 +57,8 @@ export interface ITablePageProps {
   disableSideDrawer?: boolean;
   /** list of table tools to be disabled */
   disabledTools?: TableToolsType;
+  /** If true shows checkbox to select rows */
+  enableRowSelection: boolean;
 }
 
 /**
@@ -76,6 +78,7 @@ export default function TablePage({
   disableModals,
   disableSideDrawer,
   disabledTools,
+  enableRowSelection = true,
 }: ITablePageProps) {
   const [userRoles] = useAtom(userRolesAtom, projectScope);
   const [userSettings] = useAtom(userSettingsAtom, projectScope);
@@ -179,7 +182,7 @@ export default function TablePage({
               hiddenColumns={
                 userSettings.tables?.[formatSubTableName(tableId)]?.hiddenFields
               }
-              selectedRows={selectedRowsProp}
+              selectedRows={enableRowSelection ? selectedRowsProp : undefined}
               emptyState={
                 <EmptyState
                   Icon={AddRowIcon}

--- a/src/pages/Table/TablePage.tsx
+++ b/src/pages/Table/TablePage.tsx
@@ -58,7 +58,7 @@ export interface ITablePageProps {
   /** list of table tools to be disabled */
   disabledTools?: TableToolsType;
   /** If true shows checkbox to select rows */
-  enableRowSelection: boolean;
+  enableRowSelection?: boolean;
 }
 
 /**
@@ -78,7 +78,7 @@ export default function TablePage({
   disableModals,
   disableSideDrawer,
   disabledTools,
-  enableRowSelection = true,
+  enableRowSelection = false,
 }: ITablePageProps) {
   const [userRoles] = useAtom(userRolesAtom, projectScope);
   const [userSettings] = useAtom(userSettingsAtom, projectScope);

--- a/src/pages/Table/TablePage.tsx
+++ b/src/pages/Table/TablePage.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useMemo, useState } from "react";
 import { useAtom } from "jotai";
 import { ErrorBoundary } from "react-error-boundary";
 import { isEmpty, intersection } from "lodash-es";
@@ -33,7 +33,6 @@ import {
   tableSchemaAtom,
   columnModalAtom,
   tableModalAtom,
-  tableSortsAtom,
 } from "@src/atoms/tableScope";
 import useBeforeUnload from "@src/hooks/useBeforeUnload";
 import ActionParamsProvider from "@src/components/fields/Action/FormDialog/Provider";
@@ -43,6 +42,7 @@ import { TABLE_TOOLBAR_HEIGHT } from "@src/components/TableToolbar";
 import { DRAWER_COLLAPSED_WIDTH } from "@src/components/SideDrawer";
 import { formatSubTableName } from "@src/utils/table";
 import { TableToolsType } from "@src/types/table";
+import { RowSelectionState } from "@tanstack/react-table";
 
 // prettier-ignore
 const BuildLogsSnack = lazy(() => import("@src/components/TableModals/CloudLogsModal/BuildLogs/BuildLogsSnack" /* webpackChunkName: "TableModals-BuildLogsSnack" */));
@@ -101,6 +101,21 @@ export default function TablePage({
   useBeforeUnload(columnModalAtom, tableScope);
   useBeforeUnload(tableModalAtom, tableScope);
 
+  const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
+
+  // Without useMemo we'll be stuck in an infinite loop
+  const selectedRowsProp = useMemo(
+    () => ({
+      state: selectedRows,
+      setState: setSelectedRows,
+    }),
+    [selectedRows, setSelectedRows]
+  );
+
+  const resetSelectedRows = () => {
+    setSelectedRows({});
+  };
+
   if (!(tableSchema as any)._rowy_ref)
     return (
       <>
@@ -132,7 +147,11 @@ export default function TablePage({
     <ActionParamsProvider>
       <ErrorBoundary FallbackComponent={InlineErrorFallback}>
         <Suspense fallback={<TableToolbarSkeleton />}>
-          <TableToolbar disabledTools={disabledTools} />
+          <TableToolbar
+            disabledTools={disabledTools}
+            selectedRows={selectedRows}
+            resetSelectedRows={resetSelectedRows}
+          />
         </Suspense>
       </ErrorBoundary>
 
@@ -160,6 +179,7 @@ export default function TablePage({
               hiddenColumns={
                 userSettings.tables?.[formatSubTableName(tableId)]?.hiddenFields
               }
+              selectedRows={selectedRowsProp}
               emptyState={
                 <EmptyState
                   Icon={AddRowIcon}

--- a/src/theme/CheckboxIndeterminateIcon.tsx
+++ b/src/theme/CheckboxIndeterminateIcon.tsx
@@ -47,7 +47,7 @@ export default function CheckboxIndeterminateIcon() {
           boxShadow: 1,
         },
 
-        ".Mui-checked &, [aria-selected='true'] &": {
+        ".MuiCheckbox-indeterminate &, [aria-selected='true'] &": {
           backgroundColor: "currentColor",
           borderColor: "currentColor",
 


### PR DESCRIPTION
This PR adds support for bulk deletion of rows by implementing a checkbox next to each row. The implementation is based on the [example](https://tanstack.com/table/v8/docs/examples/react/row-selection) provided by react-table.

#### Needs more attention
- Selecting a few rows should put the header checkbox in an [indeterminate](https://mui.com/material-ui/react-checkbox/#indeterminate) state. For some reason it is not working. I don't see any problem with my code/logic.
- Sometimes, after deleting rows the [`<LoadedRowStatus />`](https://github.com/rowyio/rowy/blob/develop/src/components/TableToolbar/LoadedRowsStatus.tsx) component doesn't update the total number of rows. I request someone with more experience of the codebase to look into it.
- The state for managing selected rows is set by react-table. They [set the ids](https://github.com/il3ven/rowy/blob/9b84822a1c31ac9cc5b08609f33b1dcbaedbf779/src/components/Table/Table.tsx#L234) of selected rows into the state. The [id is equal to `_rowy_ref.path`](https://github.com/il3ven/rowy/blob/9b84822a1c31ac9cc5b08609f33b1dcbaedbf779/src/components/Table/Table.tsx#L61) and the atom delete [function accepts a path](https://github.com/il3ven/rowy/blob/2715a8094aa740bd6c783ad7e28fb24f6973cded/src/atoms/tableScope/rowActions.ts#L222). In case the id is not equal to `_rowy_ref.path` the implementation will fail. I think it is not a point of worry because id should always be equal to `_rowy_ref.path`. Please correct me if I am wrong.

Note: Check the review comments for context about the decisions I have made.

/claim #809
Closes #809

https://github.com/rowyio/rowy/assets/4337699/54369216-fc09-40dc-b601-b41fc7873163

