### PR TITLE
disallow dots in collection name

### DIFF
--- a/src/components/TableSettingsDialog/form.tsx
+++ b/src/components/TableSettingsDialog/form.tsx
@@ -149,6 +149,7 @@ export const tableSettings = (
           // https://firebase.google.com/docs/firestore/quotas#collections_documents_and_fields
           validation: [
             ["matches", /^[^\s]+$/, "Collection name cannot have spaces"],
+            ["matches", /^[^.]+$/, "Collection name cannot have dots"],
             ["notOneOf", [".", ".."], "Collection name cannot be . or .."],
             [
               "test",
@@ -194,6 +195,7 @@ export const tableSettings = (
           // https://firebase.google.com/docs/firestore/quotas#collections_documents_and_fields
           validation: [
             ["matches", /^[^\s]+$/, "Collection name cannot have spaces"],
+            ["matches", /^[^.]+$/, "Collection name cannot have dots"],
             ["notOneOf", [".", ".."], "Collection name cannot be . or .."],
             [
               "test",


### PR DESCRIPTION
As seen in Discord support, table function deploy will fail if collection name contains dots. This PR adds validation on table creation modal to prevent such collection names being used.
<img width="992" alt="Screenshot 2023-06-16 at 03 17 09" src="https://github.com/rowyio/rowy/assets/34177142/f721dafe-ed21-48f9-b19c-4413c6e1a466">
(https://discord.com/channels/853498675484819476/1118858045460598797/1118860716556963910)



<img width="591" alt="Screenshot 2023-06-16 at 03 09 41" src="https://github.com/rowyio/rowy/assets/34177142/30f84917-40a0-4ef2-a8c9-dedc57368601">
