### PR TITLE
fix bug: minimize `BuildLogsSnack` upon fullscreen

### DIFF
--- a/src/components/TableModals/CloudLogsModal/BuildLogs/BuildLogsSnack.tsx
+++ b/src/components/TableModals/CloudLogsModal/BuildLogs/BuildLogsSnack.tsx
@@ -150,6 +150,7 @@ export default function BuildLogsSnack({
                   timeRange: { type: "days", value: 7 },
                   buildLogExpanded: 0,
                 });
+                setExpanded(false);
               }}
               style={{ color: "white" }}
             >


### PR DESCRIPTION
This PR fixes a bug. There is no issue for this bug so feel free to reject this PR. I found this behavior while browsing around the app and it seemed like a quick fix. Hence this PR. 

#### Current behavior 

When the `BuildLogsSnack` is maximized, clicking full screen should minimize the component before opening the modal.

https://github.com/rowyio/rowy/assets/4337699/5309d8eb-17e9-4220-ba7c-6dcfd6181a65

#### New behavior

https://github.com/rowyio/rowy/assets/4337699/49f12978-11df-41d1-8efe-3b450645e4f0


