### PR TITLE
Add code editor quick action to get secrets

### DIFF
--- a/src/components/CodeEditor/useMonacoCustomizations.ts
+++ b/src/components/CodeEditor/useMonacoCustomizations.ts
@@ -314,10 +314,10 @@ export default function useMonacoCustomizations({
     if (!secretNames.secretNames) return;
     const secretsDef = `type SecretNames = ${secretNames.secretNames
       .map((secret: string) => `"${secret}"`)
-      .join(" | ")}
+      .join(" | ")} \n
         enum secrets {
           ${secretNames.secretNames
-            .map((secret: string) => `${secret} = "${secret}"`)
+            .map((secret: string) => `"${secret}" = "${secret}"`)
             .join("\n")}
         }
        `;

--- a/src/components/CodeEditor/useMonacoCustomizations.ts
+++ b/src/components/CodeEditor/useMonacoCustomizations.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useAtom } from "jotai";
+import { matchSorter } from "match-sorter";
 
 import {
   tableScope,
@@ -82,8 +83,6 @@ export default function useMonacoCustomizations({
         "ts:filename/utils.d.ts"
       );
       monaco.languages.typescript.javascriptDefaults.addExtraLib(rowyUtilsDefs);
-
-      setLoggingReplacementActions();
     } catch (error) {
       console.error(
         "An error occurred during initialization of Monaco: ",
@@ -124,13 +123,13 @@ export default function useMonacoCustomizations({
     }
   }, [monaco, stringifiedDiagnosticsOptions]);
 
-  const setLoggingReplacementActions = () => {
+  const setReplacementActions = () => {
     if (!monaco) return;
     const { dispose } = monaco.languages.registerCodeActionProvider(
       "javascript",
       {
         provideCodeActions: (model, range, context, token) => {
-          const actions = context.markers
+          const consoleLogReplacements = context.markers
             .filter((error) => {
               return error.message.includes("Rowy Cloud Logging");
             })
@@ -156,8 +155,63 @@ export default function useMonacoCustomizations({
                 isPreferred: true,
               };
             });
+          const secretNameReplacements = context.markers
+            .filter((error) => {
+              return error.message.includes(
+                "is not assignable to parameter of type 'SecretNames'"
+              );
+            })
+            .map((error) => {
+              const typoSecretName = model
+                .getLineContent(error.startLineNumber)
+                .slice(error.startColumn, error.endColumn - 2);
+              const similarSecretNames =
+                matchSorter(secretNames.secretNames ?? [], typoSecretName) ??
+                [];
+              const otherSecretNames =
+                secretNames.secretNames?.filter(
+                  (secretName) => !similarSecretNames.includes(secretName)
+                ) ?? [];
+              return [
+                ...similarSecretNames.map((secretName) => ({
+                  title: `Replace with "${secretName}"`,
+                  diagnostics: [error],
+                  kind: "quickfix",
+                  edit: {
+                    edits: [
+                      {
+                        resource: model.uri,
+                        edit: {
+                          range: error,
+                          text: `"${secretName}"`,
+                        },
+                      },
+                    ],
+                  },
+                  isPreferred: true,
+                })),
+                ...otherSecretNames.map((secretName) => ({
+                  title: `Replace with "${secretName}"`,
+                  diagnostics: [error],
+                  kind: "quickfix",
+                  edit: {
+                    edits: [
+                      {
+                        resource: model.uri,
+                        edit: {
+                          range: error,
+                          text: `"${secretName}"`,
+                        },
+                      },
+                    ],
+                  },
+                  isPreferred: false,
+                })),
+              ];
+            })
+            .flat();
           return {
-            actions: actions,
+            actions: [...consoleLogReplacements, ...secretNameReplacements],
             dispose: () => {},
           };
         },
@@ -169,7 +223,6 @@ export default function useMonacoCustomizations({
       dispose();
     });
   };
-
   const addJsonFieldDefinition = async (
     columnKey: string,
     interfaceName: string
@@ -269,6 +322,8 @@ export default function useMonacoCustomizations({
         }
        `;
     monaco?.languages.typescript.javascriptDefaults.addExtraLib(secretsDef);
+
+    setReplacementActions();
   }, [monaco, secretNames]);
 
   let boxSx: SystemStyleObject<Theme> = {


### PR DESCRIPTION
This PR adds support for code editor quick replacements for `rowy.secrets.get` method if the provided secret name does not exist.

The list of replacement values are sorted by similarity of the provided secret name. For example, if user types a typo "whatapp" and the correct secret "whatsapp" exists in GCP Secret Manager, it will appear on the top of the list.

<img width="732" alt="Screenshot 2023-06-19 at 23 24 58" src="https://github.com/rowyio/rowy/assets/34177142/bfa089ba-112e-4dc7-b40d-4649ac170452">

<img width="733" alt="Screenshot 2023-06-19 at 23 25 16" src="https://github.com/rowyio/rowy/assets/34177142/3f51ab37-8808-439a-bae4-e5988b98d645">
