### PR TITLE
fix create table form table name glitches

### DIFF
--- a/src/components/TableSettingsDialog/TableName.tsx
+++ b/src/components/TableSettingsDialog/TableName.tsx
@@ -20,10 +20,14 @@ export default function TableName({ watchedField, ...props }: ITableNameProps) {
   const watchedValue = useWatch({ control, name: watchedField } as any);
   useEffect(() => {
     if (!disabled) {
-      if (typeof value === "string" && value.trim() !== "") {
-        onChange(value);
-      } else if (typeof watchedValue === "string" && !!watchedValue) {
+      const touched = control.getFieldState(props.name).isTouched;
+
+      if (!touched && typeof watchedValue === "string" && !!watchedValue) {
+        // if table name field is not touched, and watched value is valid, set table name to watched value
         onChange(startCase(watchedValue));
+      } else if (typeof value === "string") {
+        // otherwise if table name is valid, set watched value to table name
+        onChange(value.trim());
       }
     }
   }, [watchedValue, disabled, onChange, value]);


### PR DESCRIPTION
Fixes the following issues on the create table form:
- First table creation, table name field only automatically gets the first character of collection name, not full collection name.
- Non-first table creation, table name field does not get updated when collection name updates after the first selection.
- Full deletion of table name field populates the field with value from collection name, it should become empty.



<img width="1158" alt="Screenshot 2023-06-28 at 23 56 18" src="https://github.com/rowyio/rowy/assets/34177142/afce5f7f-447a-441a-9e90-a796d7742531">
<img width="1158" alt="Screenshot 2023-06-28 at 23 56 27" src="https://github.com/rowyio/rowy/assets/34177142/592d9419-87e0-47e9-9858-bb23a9e976c7">


Current implementation checks if table name field has values. After getting value from collection name (first collection name character for first table, or first collection name choice for non-first table), the code logic would omit any changes from collection name, causing the issues mentioned above.

New implementation checks if table name field is touched. If not touched, it will always get values from collection name, thus fixes the issues above.