### PR TITLE
Add an accessible resizing option

### DIFF
--- a/src/atoms/tableScope/table.ts
+++ b/src/atoms/tableScope/table.ts
@@ -16,7 +16,7 @@ import {
   BulkWriteFunction,
 } from "@src/types/table";
 import { updateRowData } from "@src/utils/table";
-import { Header } from "@tanstack/react-table";
+import { Table } from "@tanstack/react-table";
 
 /** Root atom from which others are derived */
 export const tableIdAtom = atom("");
@@ -49,7 +49,7 @@ export const tableColumnsOrderedAtom = atom<ColumnConfig[]>((get) => {
   );
 });
 /** Store the headers of the table as an array. */
-export const tableHeadersAtom = atom<Header<TableRow, any>[]>([]);
+export const reactTableAtom = atom<Table<TableRow> | null>(null);
 /** Reducer function to convert from array of columns to columns object */
 export const tableColumnsReducer = (
   a: Record<string, ColumnConfig>,

--- a/src/atoms/tableScope/table.ts
+++ b/src/atoms/tableScope/table.ts
@@ -48,7 +48,7 @@ export const tableColumnsOrderedAtom = atom<ColumnConfig[]>((get) => {
     ["desc", "asc"]
   );
 });
-/** Store the headers of the table as an array. */
+/** Store the table */
 export const reactTableAtom = atom<Table<TableRow> | null>(null);
 /** Reducer function to convert from array of columns to columns object */
 export const tableColumnsReducer = (

--- a/src/atoms/tableScope/table.ts
+++ b/src/atoms/tableScope/table.ts
@@ -16,6 +16,7 @@ import {
   BulkWriteFunction,
 } from "@src/types/table";
 import { updateRowData } from "@src/utils/table";
+import { Header } from "@tanstack/react-table";
 
 /** Root atom from which others are derived */
 export const tableIdAtom = atom("");
@@ -47,6 +48,8 @@ export const tableColumnsOrderedAtom = atom<ColumnConfig[]>((get) => {
     ["desc", "asc"]
   );
 });
+/** Store the headers of the table as an array. */
+export const tableHeadersAtom = atom<Header<TableRow, any>[]>([]);
 /** Reducer function to convert from array of columns to columns object */
 export const tableColumnsReducer = (
   a: Record<string, ColumnConfig>,

--- a/src/atoms/tableScope/ui.ts
+++ b/src/atoms/tableScope/ui.ts
@@ -41,7 +41,7 @@ export const columnMenuAtom = atom<{
  * ```
  */
 export const columnModalAtom = atomWithHash<{
-  type: "new" | "name" | "type" | "config";
+  type: "new" | "name" | "type" | "config" | "setColumnWidth";
   columnKey?: string;
   index?: number;
 } | null>("columnModal", null, { replaceState: true });

--- a/src/components/ColumnMenu/ColumnMenu.tsx
+++ b/src/components/ColumnMenu/ColumnMenu.tsx
@@ -24,6 +24,7 @@ import {
 } from "@src/assets/icons";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import StraightenIcon from "@mui/icons-material/Straighten";
 import EditIcon from "@mui/icons-material/EditOutlined";
 import SettingsIcon from "@mui/icons-material/SettingsOutlined";
 import EvalIcon from "@mui/icons-material/PlayCircleOutline";
@@ -262,6 +263,16 @@ export default function ColumnMenu({
           ? column.config?.renderFieldType
           : column.type
       ),
+    },
+    {
+      key: "setColumnWidth",
+      label: "Set Column Width",
+      icon: <StraightenIcon />,
+      onClick: () => {
+        openColumnModal({ type: "setColumnWidth", columnKey: column.key });
+        handleClose();
+      },
+      disabled: !column.resizable,
     },
   ];
 

--- a/src/components/ColumnMenu/ColumnMenu.tsx
+++ b/src/components/ColumnMenu/ColumnMenu.tsx
@@ -272,7 +272,7 @@ export default function ColumnMenu({
         openColumnModal({ type: "setColumnWidth", columnKey: column.key });
         handleClose();
       },
-      disabled: !column.resizable,
+      disabled: column.resizable === false,
     },
   ];
 

--- a/src/components/ColumnModals/ColumnModals.tsx
+++ b/src/components/ColumnModals/ColumnModals.tsx
@@ -5,6 +5,7 @@ import NewColumnModal from "./NewColumnModal";
 import NameChangeModal from "./NameChangeModal";
 import TypeChangeModal from "./TypeChangeModal";
 import ColumnConfigModal from "./ColumnConfigModal";
+import SetColumnWidthModal from "./SetColumnWidthModal";
 
 import {
   tableScope,
@@ -39,6 +40,9 @@ export default function ColumnModals() {
 
   if (columnModal.type === "config")
     return <ColumnConfigModal onClose={onClose} column={column} />;
+
+  if (columnModal.type === "setColumnWidth")
+    return <SetColumnWidthModal onClose={onClose} column={column} />;
 
   return null;
 }

--- a/src/components/ColumnModals/SetColumnWidthModal.tsx
+++ b/src/components/ColumnModals/SetColumnWidthModal.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { IColumnModalProps } from ".";
+import { selectedCellAtom, tableHeadersAtom } from "@src/atoms/tableScope";
+import { tableScope } from "@src/atoms/tableScope";
+import { useAtom } from "jotai";
+
+import { TextField } from "@mui/material";
+import Modal from "@src/components/Modal";
+import { TableRow } from "@src/types/table";
+import { Header } from "@tanstack/react-table";
+
+export default function ResizeColumnModal({
+  onClose,
+  column,
+}: IColumnModalProps) {
+  const [newWidth, setWidth] = useState<number>(0);
+  const [selectedCell] = useAtom(selectedCellAtom, tableScope);
+  const [tableHeaders] = useAtom(tableHeadersAtom, tableScope);
+  const [selectedHeader, setSelectedHeader] = useState<Header<
+    TableRow,
+    any
+  > | null>(null);
+
+  useEffect(() => {
+    if (selectedCell && tableHeaders) {
+      setSelectedHeader(
+        tableHeaders.find((h) => h.id === selectedCell?.columnKey) ?? null
+      );
+    }
+  }, [selectedCell, tableHeaders]);
+
+  useEffect(() => {
+    selectedHeader && setWidth(selectedHeader.getSize());
+  }, [selectedHeader]);
+
+  return (
+    <Modal
+      onClose={onClose}
+      title="Set Column Width"
+      maxWidth="xs"
+      children={
+        <TextField
+          value={newWidth}
+          autoFocus
+          variant="filled"
+          id="name"
+          label="Width"
+          type="number"
+          fullWidth
+          onChange={(e) => setWidth(Number(e.target.value))}
+        />
+      }
+      actions={{
+        primary: {
+          onMouseDown: (e) => {
+            selectedHeader &&
+              selectedHeader.getResizeHandler()({
+                clientX: e.clientX - (newWidth - selectedHeader.getSize()),
+              } as any);
+            onClose();
+          },
+          children: "Update",
+        },
+        secondary: {
+          onClick: onClose,
+          children: "Cancel",
+        },
+      }}
+    />
+  );
+}

--- a/src/components/ColumnModals/SetColumnWidthModal.tsx
+++ b/src/components/ColumnModals/SetColumnWidthModal.tsx
@@ -23,7 +23,7 @@ export default function SetColumnWidthModal({
     reactTable?.setColumnSizing((old) => {
       const newSizing = { ...old };
       // Set the new width for the column.
-      newSizing[column.name] = newWidth;
+      newSizing[column.fieldName] = newWidth;
       return newSizing;
     });
     onClose();
@@ -35,24 +35,30 @@ export default function SetColumnWidthModal({
       title="Set Column Width"
       maxWidth="xs"
       children={
-        <TextField
-          value={newWidth}
-          autoFocus
-          variant="filled"
-          id="name"
-          label="Width"
-          type="number"
-          fullWidth
-          onChange={(e) => setWidth(Number(e.target.value))}
-          onKeyDown={(e) => {
-            e.key === "Enter" && handleUpdate();
+        <form
+          id="column-width-modal"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleUpdate();
           }}
-        />
+        >
+          <TextField
+            value={newWidth}
+            autoFocus
+            variant="filled"
+            id="name"
+            label="Width"
+            type="number"
+            fullWidth
+            onChange={(e) => setWidth(Number(e.target.value))}
+          />
+        </form>
       }
       actions={{
         primary: {
-          onClick: handleUpdate,
           children: "Update",
+          type: "submit",
+          form: "column-width-modal",
         },
         secondary: {
           onClick: onClose,

--- a/src/components/ColumnModals/SetColumnWidthModal.tsx
+++ b/src/components/ColumnModals/SetColumnWidthModal.tsx
@@ -9,7 +9,7 @@ import Modal from "@src/components/Modal";
 import { TableRow } from "@src/types/table";
 import { Header } from "@tanstack/react-table";
 
-export default function ResizeColumnModal({
+export default function SetColumnWidthModal({
   onClose,
   column,
 }: IColumnModalProps) {

--- a/src/components/ColumnModals/SetColumnWidthModal.tsx
+++ b/src/components/ColumnModals/SetColumnWidthModal.tsx
@@ -15,12 +15,14 @@ export default function SetColumnWidthModal({
   const [newWidth, setWidth] = useState<number>(0);
 
   useEffect(() => {
+    // Set the initial width to the current column width once the table is fetched.
     setWidth(reactTable?.getAllColumns()[column.index].getSize() || 0);
   }, [reactTable, column]);
 
   const handleUpdate = () => {
     reactTable?.setColumnSizing((old) => {
       const newSizing = { ...old };
+      // Set the new width for the column.
       newSizing[column.name] = newWidth;
       return newSizing;
     });

--- a/src/components/ColumnModals/SetColumnWidthModal.tsx
+++ b/src/components/ColumnModals/SetColumnWidthModal.tsx
@@ -52,7 +52,7 @@ export default function ResizeColumnModal({
       }
       actions={{
         primary: {
-          onMouseDown: (e) => {
+          onMouseUp: (e) => {
             selectedHeader &&
               selectedHeader.getResizeHandler()({
                 clientX: e.clientX - (newWidth - selectedHeader.getSize()),

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -100,6 +100,7 @@ export default function Table({
   const [tableRows] = useAtom(tableRowsAtom, tableScope);
   const [tableNextPage] = useAtom(tableNextPageAtom, tableScope);
   const [tablePage, setTablePage] = useAtom(tablePageAtom, tableScope);
+  const setReactTable = useSetAtom(reactTableAtom, tableScope);
 
   const updateColumn = useSetAtom(updateColumnAtom, tableScope);
 
@@ -186,7 +187,7 @@ export default function Table({
     state: { ...prev.state, columnVisibility, columnPinning, columnSizing },
     onColumnSizingChange: setColumnSizing,
   }));
-  const setReactTable = useSetAtom(reactTableAtom, tableScope);
+  // Update the reactTable atom when table state changes.
   useMemo(() => {
     setReactTable(table);
   }, [table, setReactTable]);

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-table";
 import type {
   ColumnPinningState,
+  Header,
   VisibilityState,
 } from "@tanstack/react-table";
 import { DropResult } from "react-beautiful-dnd";
@@ -25,6 +26,7 @@ import EmptyState from "@src/components/EmptyState";
 import {
   tableScope,
   tableSchemaAtom,
+  tableHeadersAtom,
   tableColumnsOrderedAtom,
   tableRowsAtom,
   tableNextPageAtom,
@@ -96,6 +98,7 @@ export default function Table({
 }: ITableProps) {
   const [tableSchema] = useAtom(tableSchemaAtom, tableScope);
   const [tableColumnsOrdered] = useAtom(tableColumnsOrderedAtom, tableScope);
+  const setTableHeaders = useSetAtom(tableHeadersAtom, tableScope);
   const [tableRows] = useAtom(tableRowsAtom, tableScope);
   const [tableNextPage] = useAtom(tableNextPageAtom, tableScope);
   const [tablePage, setTablePage] = useAtom(tablePageAtom, tableScope);
@@ -185,6 +188,17 @@ export default function Table({
     state: { ...prev.state, columnVisibility, columnPinning, columnSizing },
     onColumnSizingChange: setColumnSizing,
   }));
+  // Store the headers of the current table as an array.
+  // Initial value is an empty array, which progressively grows as headerGroups are cycled through
+  // and their headers are added to the array.
+  setTableHeaders(
+    table.getHeaderGroups().reduce((currentHeadersList, headerGroup) => {
+      return [
+        ...currentHeadersList,
+        ...headerGroup.headers.map((header) => header),
+      ];
+    }, [] as Header<TableRow, any>[])
+  );
   // Get rows and columns for virtualization
   const { rows } = table.getRowModel();
   const leafColumns = table.getVisibleLeafColumns();

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -9,7 +9,6 @@ import {
 } from "@tanstack/react-table";
 import type {
   ColumnPinningState,
-  Header,
   VisibilityState,
 } from "@tanstack/react-table";
 import { DropResult } from "react-beautiful-dnd";
@@ -26,7 +25,7 @@ import EmptyState from "@src/components/EmptyState";
 import {
   tableScope,
   tableSchemaAtom,
-  tableHeadersAtom,
+  reactTableAtom,
   tableColumnsOrderedAtom,
   tableRowsAtom,
   tableNextPageAtom,
@@ -98,7 +97,6 @@ export default function Table({
 }: ITableProps) {
   const [tableSchema] = useAtom(tableSchemaAtom, tableScope);
   const [tableColumnsOrdered] = useAtom(tableColumnsOrderedAtom, tableScope);
-  const setTableHeaders = useSetAtom(tableHeadersAtom, tableScope);
   const [tableRows] = useAtom(tableRowsAtom, tableScope);
   const [tableNextPage] = useAtom(tableNextPageAtom, tableScope);
   const [tablePage, setTablePage] = useAtom(tablePageAtom, tableScope);
@@ -188,14 +186,10 @@ export default function Table({
     state: { ...prev.state, columnVisibility, columnPinning, columnSizing },
     onColumnSizingChange: setColumnSizing,
   }));
-  // Store the headers of the current table as an array.
-  // Initial value is an empty array, which progressively grows as headerGroups are cycled through
-  // and their headers are added to the array.
-  setTableHeaders(
-    table.getHeaderGroups().reduce((currentHeadersList, headerGroup) => {
-      return [...currentHeadersList, ...headerGroup.headers];
-    }, [] as Header<TableRow, any>[])
-  );
+  const setReactTable = useSetAtom(reactTableAtom, tableScope);
+  useMemo(() => {
+    setReactTable(table);
+  }, [table, setReactTable]);
   // Get rows and columns for virtualization
   const { rows } = table.getRowModel();
   const leafColumns = table.getVisibleLeafColumns();

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -193,10 +193,7 @@ export default function Table({
   // and their headers are added to the array.
   setTableHeaders(
     table.getHeaderGroups().reduce((currentHeadersList, headerGroup) => {
-      return [
-        ...currentHeadersList,
-        ...headerGroup.headers.map((header) => header),
-      ];
+      return [...currentHeadersList, ...headerGroup.headers];
     }, [] as Header<TableRow, any>[])
   );
   // Get rows and columns for virtualization


### PR DESCRIPTION
Fixes #563.

 - Created a new atom to store the table.
 - Width is updated via `setColumnSizing()`.
 - The _"Save column sizes for all users?"_ prompt shows up upon updating the width.
 
Functioning:
- Adds an option to the column context menu -- "Set Column Width". Option is disabled if resizing is disabled.
- Selecting it opens up a modal with a single number input field, pre-filled with the current width of the column.
- Entering a new value and hitting Update resizes the column as needed.