### PR TITLE
Table name textbox UI error fix

### DIFF
--- a/src/components/TableSettingsDialog/TableName.tsx
+++ b/src/components/TableSettingsDialog/TableName.tsx
@@ -27,7 +27,7 @@ export default function TableName({ watchedField, ...props }: ITableNameProps) {
         onChange(startCase(watchedValue));
       } else if (typeof value === "string") {
         // otherwise if table name is valid, set watched value to table name
-        onChange(value.trim());
+        onChange(startCase(value.trim()));
       }
     }
   }, [watchedValue, disabled, onChange, value]);

--- a/src/components/TableSettingsDialog/form.tsx
+++ b/src/components/TableSettingsDialog/form.tsx
@@ -213,7 +213,7 @@ export const tableSettings = (
       name: "name",
       label: "Table name",
       required: true,
-      watchedField: "collection",
+      watchedField: "name",
       assistiveText: "User-facing name for this table",
       autoFocus: true,
       gridCols: { xs: 12, sm: 6 },


### PR DESCRIPTION
closes #1409 
It was watching the wrong field i.e. collection due to which the watchvalue will always be equal to the collection name. 
Also, I have added consistency in the startCase through which if you switch your input focus and comeback again on tablename field the startCase consistency would be maintained.