### PR TITLE
Ability to edit field keys when importing CSVs

### DIFF
--- a/src/components/TableModals/ImportCsvWizard/ImportCsvWizard.tsx
+++ b/src/components/TableModals/ImportCsvWizard/ImportCsvWizard.tsx
@@ -323,7 +323,9 @@ export default function ImportCsvWizard({ onClose }: ITableModalProps) {
             disableNext:
               config.pairs.length === 0 ||
               !validRows ||
-              (config.documentId === "column" && !config.documentIdCsvKey),
+              (config.documentId === "column" && !config.documentIdCsvKey) ||
+              config.pairs.some((pair) => !pair.columnKey) ||
+              config.newColumns.some((col) => !col.key),
           },
           config.newColumns.length > 0 && {
             title: "Set column types",

--- a/src/components/TableModals/ImportCsvWizard/Step1Columns.tsx
+++ b/src/components/TableModals/ImportCsvWizard/Step1Columns.tsx
@@ -257,8 +257,16 @@ export default function Step1Columns({
           const isNewColumn = !!find(config.newColumns, { key: columnKey });
 
           return (
-            <Grid container key={field} component="li" wrap="nowrap">
-              <Grid item xs>
+            <Grid
+              container
+              key={field}
+              component="li"
+              wrap="nowrap"
+              sx={{
+                marginTop: "36px !important",
+              }}
+            >
+              <Grid container item xs alignItems={"center"}>
                 <FormControlLabel
                   key={field}
                   control={
@@ -291,88 +299,145 @@ export default function Step1Columns({
                 <ArrowIcon color="disabled" sx={{ color: "secondary.main" }} />
               </Grid>
 
-              <Grid item xs>
+              <Grid item container spacing={4} xs alignItems={"center"}>
                 {selected && (
-                  <ColumnSelect
-                    multiple={false}
-                    value={columnKey}
-                    onChange={handleChange(field) as any}
-                    TextFieldProps={{
-                      hiddenLabel: true,
-                      SelectProps: {
-                        renderValue: () => {
-                          if (!columnKey) return "Select or add column";
-                          else
-                            return (
-                              <Stack
-                                direction="row"
-                                gap={1}
-                                alignItems="center"
-                              >
-                                <Box sx={{ width: 24, height: 24 }}>
-                                  {!isNewColumn ? (
-                                    getFieldProp("icon", matchingColumn?.type)
-                                  ) : (
-                                    <TableColumnIcon color="disabled" />
-                                  )}
-                                </Box>
-                                {matchingColumn?.name}
-                                {isNewColumn && (
-                                  <Chip
-                                    label="New"
-                                    color="primary"
-                                    size="small"
-                                    variant="outlined"
-                                    style={{
-                                      marginLeft: "auto",
-                                      pointerEvents: "none",
-                                      height: 24,
-                                      fontWeight: "normal",
-                                    }}
-                                  />
-                                )}
-                              </Stack>
-                            );
-                        },
-                        sx: [
-                          {
-                            backgroundColor: "background.default",
-                            border: (theme) =>
-                              `1px solid ${theme.palette.divider}`,
-                            borderRadius: 0,
-                            boxShadow: "none",
-                            "& .MuiSelect-select": {
-                              boxSizing: "border-box",
-                              height: COLUMN_HEADER_HEIGHT - 2,
-                              typography: "caption",
-                              fontWeight: "medium",
-                              lineHeight: "28px",
+                  <>
+                    <Grid item xs>
+                      <ColumnSelect
+                        multiple={false}
+                        value={columnKey}
+                        onChange={handleChange(field) as any}
+                        TextFieldProps={{
+                          hiddenLabel: true,
+                          SelectProps: {
+                            renderValue: () => {
+                              if (!columnKey) return "Select or add column";
+                              else
+                                return (
+                                  <Stack
+                                    direction="row"
+                                    gap={1}
+                                    alignItems="center"
+                                  >
+                                    <Box sx={{ width: 24, height: 24 }}>
+                                      {!isNewColumn ? (
+                                        getFieldProp(
+                                          "icon",
+                                          matchingColumn?.type
+                                        )
+                                      ) : (
+                                        <TableColumnIcon color="disabled" />
+                                      )}
+                                    </Box>
+                                    {matchingColumn?.name}
+                                    {isNewColumn && (
+                                      <Chip
+                                        label="New"
+                                        color="primary"
+                                        size="small"
+                                        variant="outlined"
+                                        style={{
+                                          marginLeft: "auto",
+                                          pointerEvents: "none",
+                                          height: 24,
+                                          fontWeight: "normal",
+                                        }}
+                                      />
+                                    )}
+                                  </Stack>
+                                );
                             },
+                            sx: [
+                              {
+                                backgroundColor: "background.default",
+                                border: (theme) =>
+                                  `1px solid ${theme.palette.divider}`,
+                                borderRadius: 0,
+                                boxShadow: "none",
+                                "& .MuiSelect-select": {
+                                  boxSizing: "border-box",
+                                  height: COLUMN_HEADER_HEIGHT - 2,
+                                  typography: "caption",
+                                  fontWeight: "medium",
+                                  lineHeight: "28px",
+                                },
 
-                            color: "text.secondary",
-                            "&:hover": {
-                              backgroundColor: "background.default",
-                              color: "text.primary",
-                              boxShadow: "none",
-                            },
+                                color: "text.secondary",
+                                "&:hover": {
+                                  backgroundColor: "background.default",
+                                  color: "text.primary",
+                                  boxShadow: "none",
+                                },
 
-                            "&::before": { content: "none" },
-                            "&::after": { pointerEvents: "none" },
+                                "&::before": { content: "none" },
+                                "&::after": { pointerEvents: "none" },
+                              },
+                              !columnKey && { color: "text.disabled" },
+                            ],
                           },
-                          !columnKey && { color: "text.disabled" },
-                        ],
-                      },
-                      sx: { "& .MuiInputLabel-root": { display: "none" } },
-                    }}
-                    clearable={false}
-                    displayEmpty
-                    freeText
-                    AddButtonProps={{ children: "Create column…" }}
-                    AddDialogProps={{
-                      title: "Create column",
-                      textFieldLabel: "Column name",
-                    }}
-                  />
+                          sx: { "& .MuiInputLabel-root": { display: "none" } },
+                        }}
+                        clearable={false}
+                        displayEmpty
+                        freeText
+                        AddButtonProps={{ children: "Create column…" }}
+                        AddDialogProps={{
+                          title: "Create column",
+                          textFieldLabel: "Column name",
+                        }}
+                      />
+                    </Grid>
+                    <Grid item>
+                      <TextField
+                        label="Field key"
+                        value={
+                          config.pairs.find(
+                            (pair) => pair.columnKey === columnKey
+                          )?.columnKey ??
+                          config.newColumns.find(
+                            (pair) => pair.key === columnKey
+                          )?.key
+                        }
+                        onChange={(e) => {
+                          const newKey = e.target.value;
+                          const newPairs = config.pairs.map((pair) => {
+                            if (pair.columnKey === columnKey) {
+                              return { ...pair, columnKey: newKey };
+                            } else {
+                              return pair;
+                            }
+                          });
+
+                          const newColumns = config.newColumns.map((column) => {
+                            if (column.key === columnKey) {
+                              return {
+                                ...column,
+                                key: newKey,
+                                fieldName: newKey,
+                              };
+                            } else {
+                              return column;
+                            }
+                          });
+
+                          setConfig((config) => ({
+                            ...config,
+                            pairs: newPairs,
+                            newColumns,
+                          }));
+                        }}
+                        sx={{
+                          "& .MuiInputLabel-root": {
+                            position: "absolute",
+                            transform: "translateY(-100%)",
+                          },
+                          "& .MuiInputBase-root": {
+                            height: 40,
+                          },
+                        }}
+                      />
+                    </Grid>
+                  </>
                 )}
               </Grid>
             </Grid>


### PR DESCRIPTION
A "proof-of-concept"-ey implementation of what [the 2nd solution](https://github.com/rowyio/rowy/issues/1418#issuecomment-1736043543) could look like for #1418.

Field key values are just the column name in camelCase by default, can now be edited.
![image](https://github.com/rowyio/rowy/assets/78612244/867abb94-1d53-4ad3-9881-aab29025fde5)
![image](https://github.com/rowyio/rowy/assets/78612244/2e697f1e-9036-4367-8ab2-b57bc691fff0)
![image](https://github.com/rowyio/rowy/assets/78612244/428e074d-a677-40eb-8da7-53443b503efe)
