### PR TITLE
Retrieve clipboard data from ClipboardEvent instead

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -285,7 +285,7 @@ export default function Table({
   const { handler: hotKeysHandler } = useHotKeys([
     ["mod+C", handleCopy],
     ["mod+X", handleCut],
-    ["mod+V", handlePaste],
+    ["mod+V", (e) => handlePaste], // So the event isn't passed to the handler
   ]);
 
   // Handle prompt to save local column sizes if user `canEditColumns`
@@ -323,6 +323,14 @@ export default function Table({
   useEffect(() => {
     fetchMoreOnBottomReached(containerRef.current);
   }, [fetchMoreOnBottomReached, tableNextPage.loading, containerRef]);
+
+  useEffect(() => {
+    document.addEventListener("paste", handlePaste);
+
+    return () => {
+      document.removeEventListener("paste", handlePaste);
+    };
+  }, [handlePaste]);
 
   // apply user default sort on first render
   const [applySort, setApplySort] = useState(true);

--- a/src/components/Table/useHotKey.tsx
+++ b/src/components/Table/useHotKey.tsx
@@ -12,7 +12,6 @@ export default function useHotKeys(actions: HotKeysAction[]) {
       const event_ = "nativeEvent" in event ? event.nativeEvent : event;
       actions.forEach(([hotkey, handler_]) => {
         if (getHotkeyMatcher(hotkey)(event_)) {
-          event.preventDefault();
           handler_(event_);
         }
       });

--- a/src/components/Table/useMenuAction.tsx
+++ b/src/components/Table/useMenuAction.tsx
@@ -169,6 +169,13 @@ export function useMenuAction(
         // Firefox doesn't allow for reading clipboard data, hence the workaround
         if (navigator.userAgent.includes("Firefox")) {
           if (!e || !e.clipboardData) {
+            enqueueSnackbar(
+              `If you're on Firefox, please use the hotkey instead (Ctrl + V / Cmd + V).`,
+              {
+                variant: "info",
+                autoHideDuration: 7000,
+              }
+            );
             enqueueSnackbar(`Cannot read clipboard data.`, {
               variant: "error",
             });


### PR DESCRIPTION
Allows for pasting content into table cells using hotkeys in Firefox.