### PR TITLE
fix buildship template change object

### DIFF
--- a/src/components/TableModals/ExtensionsModal/utils.ts
+++ b/src/components/TableModals/ExtensionsModal/utils.ts
@@ -80,8 +80,8 @@ const extensionBodyTemplate = {
         path: ref.path
       },
       change: {
-        before: change.before.get(),
-        after: change.after.get(),
+        before: change.before.data(),
+        after: change.after.data(),
       },
       // Add your own payload here
     })


### PR DESCRIPTION
Fixes https://discord.com/channels/853498675484819476/1167845816543744190/1167845816543744190.

There is a typo in the BuildShip extension template. `change.before.get` is used to get a single field which expects an argument, in this template, `change.before.data` is the correct method as it returns the document data.