### PR TITLE
Added confirmation for bulk deletion of rows

### DIFF
--- a/src/components/TableToolbar/TableToolbar.tsx
+++ b/src/components/TableToolbar/TableToolbar.tsx
@@ -26,6 +26,8 @@ import {
   userRolesAtom,
   compatibleRowyRunVersionAtom,
   rowyRunModalAtom,
+  altPressAtom,
+  confirmDialogAtom,
 } from "@src/atoms/projectScope";
 import {
   tableScope,
@@ -91,6 +93,8 @@ function RowSelectedToolBar({
 }) {
   const [serverDocCount] = useAtom(serverDocCountAtom, tableScope);
   const deleteRow = useSetAtom(deleteRowAtom, tableScope);
+  const [altPress] = useAtom(altPressAtom, projectScope);
+  const confirm = useSetAtom(confirmDialogAtom, projectScope);
 
   const handleDelete = async () => {
     await deleteRow({ path: Object.keys(selectedRows) });
@@ -107,7 +111,20 @@ function RowSelectedToolBar({
           variant="outlined"
           startIcon={<DeleteIcon fontSize="small" />}
           color="error"
-          onClick={handleDelete}
+          onClick={
+            altPress
+              ? handleDelete
+              : () => {
+                  confirm({
+                    title: `Delete ${
+                      Object.values(selectedRows).length
+                    } of ${serverDocCount} selected rows?`,
+                    confirm: "Delete",
+                    confirmColor: "error",
+                    handleConfirm: handleDelete,
+                  });
+                }
+          }
         >
           Delete
         </Button>


### PR DESCRIPTION
Fixes #1455 

This PR adds a confirmation modal for deleting rows in bulk.

### Screenshot of the change

<img width="1792" alt="Screenshot 2023-11-01 at 4 18 39 PM" src="https://github.com/rowyio/rowy/assets/34344234/68a6cc6e-4b0a-4766-9f4f-b5abaded15ef">
