### PR TITLE
fix(CSV import): error while using a column as row id

### DIFF
--- a/src/components/TableModals/ImportCsvWizard/ImportCsvWizard.tsx
+++ b/src/components/TableModals/ImportCsvWizard/ImportCsvWizard.tsx
@@ -142,7 +142,7 @@ export default function ImportCsvWizard({ onClose }: ITableModalProps) {
     let requiredUploads: any = {};
     columns.forEach((column, index) => {
       if (needsConverter(column.type)) {
-        requiredConverts[index] = getConverter(column.type);
+        requiredConverts[column.columnKey] = getConverter(column.type);
         // console.log({ needsUploadTypes }, column.type);
         if (needsUploadTypes(column.type)) {
           requiredUploads[column.fieldName + ""] = true;
@@ -215,8 +215,8 @@ export default function ImportCsvWizard({ onClose }: ITableModalProps) {
       const newValidRows = validRows.map((row) => {
         // Convert required values
         Object.keys(row).forEach((key, i) => {
-          if (requiredConverts[i]) {
-            row[key] = requiredConverts[i](row[key]);
+          if (requiredConverts[key]) {
+            row[key] = requiredConverts[key](row[key]);
           }
         });
 


### PR DESCRIPTION
**User's issue:**
User have reported an issue with batch importing CSV files when selecting a custom column for Document IDs. Although importing the same CSV with auto-generated Document IDs works, choosing a specific column as Document IDs leads to an error: "n.charAt is not a function."

**Cause:**
Column types like reference and image, require custom parsers. Previously, these parsers were stored in an object with the column index as the key. However, when using a custom document ID, the explicit setting of the document ID resulted in a change to the column index reference.

**Fix:**
The fix involves using the column key as the key to store the parsers, rather than relying on the column index. 