### PR TITLE
ROWY-2110 fix broken table id prefill for table setup

### DIFF
--- a/src/components/TableSettingsDialog/TableName.tsx
+++ b/src/components/TableSettingsDialog/TableName.tsx
@@ -12,7 +12,7 @@ export interface ITableNameProps extends IShortTextComponentProps {
 
 export default function TableName({ watchedField, ...props }: ITableNameProps) {
   const {
-    field: { onChange, value },
+    field: { onChange },
     useFormMethods: { control },
     disabled,
   } = props;
@@ -25,12 +25,9 @@ export default function TableName({ watchedField, ...props }: ITableNameProps) {
       if (!touched && typeof watchedValue === "string" && !!watchedValue) {
         // if table name field is not touched, and watched value is valid, set table name to watched value
         onChange(startCase(watchedValue));
-      } else if (typeof value === "string") {
-        // otherwise if table name is valid, set watched value to table name
-        onChange(startCase(value.trim()));
       }
     }
-  }, [watchedValue, disabled, onChange, value]);
+  }, [watchedValue, disabled]);
 
   return <ShortTextComponent {...props} />;
 }

--- a/src/components/TableSettingsDialog/form.tsx
+++ b/src/components/TableSettingsDialog/form.tsx
@@ -213,7 +213,7 @@ export const tableSettings = (
       name: "name",
       label: "Table name",
       required: true,
-      watchedField: "name",
+      watchedField: "collection",
       assistiveText: "User-facing name for this table",
       autoFocus: true,
       gridCols: { xs: 12, sm: 6 },


### PR DESCRIPTION
https://github.com/rowyio/rowy/pull/1412 fixed https://github.com/rowyio/rowy/issues/1409 but broke the autofill of table name field which is derived from collection name.

This PR brings the autofill back and also fixed https://github.com/rowyio/rowy/issues/1409.