### PR TITLE
enabled paste functionality

### DIFF
--- a/src/components/Table/useMenuAction.tsx
+++ b/src/components/Table/useMenuAction.tsx
@@ -83,6 +83,8 @@ export const SUPPORTED_TYPES_PASTE = new Set([
   FieldType.markdown,
   // CONNECTION
   FieldType.reference,
+  // ARRAY SUBTABLE
+  FieldType.arraySubTable,
 ]);
 
 export function useMenuAction(


### PR DESCRIPTION
/claim #1523

I have tried to enable paste functionaltiy in ARRAY_SUBTABLE field, now the error you have posted is no longer coming but a different error is coming for string type as shown below:
![image](https://github.com/rowyio/rowy/assets/36031226/27fb12f8-fb2e-41f8-8ae3-218e2d7afa9a)
Could you please provide me your feedback for this new error coming or it is the error that should actually come while pasting a string in ARRAY_SUBTABLE field.