### PR TITLE
Fix table sort does not work if table has formula column

### DIFF
--- a/src/atoms/tableScope/rowActions.ts
+++ b/src/atoms/tableScope/rowActions.ts
@@ -386,9 +386,7 @@ export const updateFieldAtom = atom(
     );
 
     if (!row) throw new Error("Could not find row");
-    const isLocalRow =
-      fieldName.startsWith("_rowy_formulaValue_") ||
-      Boolean(find(tableRowsLocal, ["_rowy_ref.path", path]));
+    const isLocalRow = Boolean(find(tableRowsLocal, ["_rowy_ref.path", path]));
 
     const update: Partial<TableRow> = {};
 
@@ -468,14 +466,6 @@ export const updateFieldAtom = atom(
         row: localUpdate,
         deleteFields: deleteField ? [fieldName] : [],
       });
-
-      // TODO(han): Formula field persistence
-      // const config = find(tableColumnsOrdered, (c) => {
-      //  const [, key] = fieldName.split("_rowy_formulaValue_");
-      //  return c.key === key;
-      // });
-      // if(!config.persist) return;
-      if (fieldName.startsWith("_rowy_formulaValue")) return;
 
       // If it has no missingRequiredFields, also write to db
       // And write entire row to handle the case where it doesn’t exist in db yet

--- a/src/components/fields/Formula/TableSourcePreview.ts
+++ b/src/components/fields/Formula/TableSourcePreview.ts
@@ -6,9 +6,7 @@ import {
   _deleteRowDbAtom,
   _updateRowDbAtom,
   tableNextPageAtom,
-  tableRowsAtom,
   tableRowsDbAtom,
-  tableRowsLocalAtom,
   tableScope,
   tableSettingsAtom,
 } from "@src/atoms/tableScope";


### PR DESCRIPTION
## Issue

Sort does not work if table has formula column.

Example:  in this table setup, the right-most column is a formula column. The table sort is set to num descending, however the table UI displays rows order incorrectly.

<img width="744" alt="Screenshot 2024-01-23 at 07 26 43" src="https://github.com/rowyio/rowy/assets/34177142/0f31fbb8-819a-4bbc-9d79-2cebcbda35db">

## Cause

In a [commit](https://github.com/rowyio/rowy/commit/2715a8094aa740bd6c783ad7e28fb24f6973cded#diff-2a9e818ac35e243edc7e9fa19ab3c1d03991ab452c82e1ececbef1b0ba93247eR389-R390) related to formula field, it sets all rows to `rowsLocal` if there is formula column in the table. 
https://github.com/rowyio/rowy/blob/2715a8094aa740bd6c783ad7e28fb24f6973cded/src/atoms/tableScope/rowActions.ts#L389-L391

`rowsLocal` is designed to hold our of order rows that are supposed to be a very small set, and they are always displayed at the top of the table UI. They are not sorted or ordered.
https://github.com/rowyio/rowy/blob/0099bd1daca3f722b05ebbd5294eb31837382b2d/src/atoms/tableScope/table.ts#L170-L197

However, the commit would set all rows to rowsLocal, as a result, rows are displayed without going through filters or sorts.

## Fix

Simply remove the condition for local row would fix this issue.
```js
fieldName.startsWith("_rowy_formulaValue_")
```

After fix:
<img width="747" alt="Screenshot 2024-01-23 at 07 25 17" src="https://github.com/rowyio/rowy/assets/34177142/21984ebe-f736-4b19-82ce-aac8f9a9c28e">