### PR TITLE
Search table animation fixed regardless of the number of tables

### DIFF
--- a/src/components/Tables/TableGrid/TableGrid.tsx
+++ b/src/components/Tables/TableGrid/TableGrid.tsx
@@ -28,11 +28,7 @@ export default function TableGrid({
               if (!table) return null;
 
               return (
-                <SlideTransition
-                  key={table.id}
-                  appear
-                  timeout={(sectionIndex + 1) * 100 + tableIndex * 50}
-                >
+                <SlideTransition key={table.id} appear timeout={100}>
                   <Grid item xs={12} sm={6} md={4} lg={3}>
                     <TableCard
                       {...table}


### PR DESCRIPTION
/claim #1531 

I have fixed the table animation time to 100msec (before it was dependent on the index of the table), found out this works the best.

https://github.com/rowyio/rowy/assets/58873530/03819868-eb87-4a91-83ae-cbd7d358594f


