### PR TITLE
fix: search table result loading

### DIFF
--- a/src/components/Tables/TableGrid/TableGrid.tsx
+++ b/src/components/Tables/TableGrid/TableGrid.tsx
@@ -31,7 +31,7 @@ export default function TableGrid({
                 <SlideTransition
                   key={table.id}
                   appear
-                  timeout={(sectionIndex + 1) * 100 + tableIndex * 50}
+                  timeout={(sectionIndex + 1) * 50 + tableIndex * 25}
                 >
                   <Grid item xs={12} sm={6} md={4} lg={3}>
                     <TableCard
@@ -53,7 +53,7 @@ export default function TableGrid({
                 <SlideTransition
                   key={"grid-section-" + sectionName}
                   in
-                  timeout={(sectionIndex + 1) * 100}
+                  timeout={(sectionIndex + 1) * 50}
                 >
                   <SectionHeading sx={{ pl: 2, pr: 1.5 }}>
                     {sectionName}

--- a/src/pages/TablesPage.tsx
+++ b/src/pages/TablesPage.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useSetAtom } from "jotai";
-import { find, groupBy, sortBy } from "lodash-es";
+import { find, groupBy, sortBy, debounce } from "lodash-es";
 import { Link } from "react-router-dom";
 
 import {
@@ -63,6 +63,9 @@ export default function TablesPage() {
     tables ?? [],
     SEARCH_KEYS
   );
+
+  // Debounce the handleQuery function with a delay of 300 milliseconds
+  const debouncedHandleQuery = debounce((value) => handleQuery(value), 300);
 
   const favorites = Array.isArray(userSettings.favoriteTables)
     ? userSettings.favoriteTables
@@ -183,7 +186,7 @@ export default function TablesPage() {
     <Container component="main" sx={{ px: 1, pt: 1, pb: 7 + 3 + 3 }}>
       <FloatingSearch
         label="Search tables"
-        onChange={(e) => handleQuery(e.target.value)}
+        onChange={(e) => debouncedHandleQuery(e.target.value)}
         paperSx={{
           maxWidth: (theme) => ({
             md: theme.breakpoints.values.sm - 48 * 4,


### PR DESCRIPTION
/claim https://github.com/rowyio/rowy/issues/1531

Fix - Animation to search tables loading

Implemented -

1. Decreased the values used in the timeout prop for the SlideTransition components.
2. Avoid unnecessary rendering when the user types aggressively, using the debounce technique.

Demo -

https://github.com/rowyio/rowy/assets/34344234/dd3bc50e-0f4b-4374-a861-f9ff72ee5a84

