### PR TITLE
Fix/animation to search tables loading issue #1531

### DIFF
--- a/src/components/Tables/TableGrid/TableGrid.tsx
+++ b/src/components/Tables/TableGrid/TableGrid.tsx
@@ -31,7 +31,7 @@ export default function TableGrid({
                 <SlideTransition
                   key={table.id}
                   appear
-                  //timeout={(sectionIndex + 1) * 100 + tableIndex * 50}
+                  timeout={(sectionIndex + 1) * 0 + tableIndex * 0}
                 >
                   <Grid item xs={12} sm={6} md={4} lg={3}>
                     <TableCard

--- a/src/components/Tables/TableGrid/TableGrid.tsx
+++ b/src/components/Tables/TableGrid/TableGrid.tsx
@@ -31,7 +31,7 @@ export default function TableGrid({
                 <SlideTransition
                   key={table.id}
                   appear
-                  timeout={(sectionIndex + 1) * 100 + tableIndex * 50}
+                  //timeout={(sectionIndex + 1) * 100 + tableIndex * 50}
                 >
                   <Grid item xs={12} sm={6} md={4} lg={3}>
                     <TableCard

--- a/src/hooks/useBasicSearch.ts
+++ b/src/hooks/useBasicSearch.ts
@@ -5,7 +5,7 @@ import { matchSorter, rankings } from "match-sorter";
 export function useBasicSearch<T>(
   list: T[],
   keys: string[],
-  debounce: number = 400
+  debounce: number = 200
 ) {
   const [query, setQuery] = useState("");
   const handleQuery = useDebouncedCallback(setQuery, debounce);


### PR DESCRIPTION
Fix/animation to search tables loading issue #1531

/claim #1531

Implemented -

update TableGrid.tsx :  timeout={(sectionIndex + 1) * 0 + tableIndex * 0}
update useBasicSearch.tsx : set debounce number 200

Video : 


https://github.com/rowyio/rowy/assets/142595758/bf0368e8-1a6c-45a5-b726-e01048e2cedd







