### PR TITLE
fix: Cannot apply filter on slider

### DIFF
--- a/src/components/TableToolbar/Filters/FilterInputs.tsx
+++ b/src/components/TableToolbar/Filters/FilterInputs.tsx
@@ -40,6 +40,7 @@ export interface IFilterInputsProps {
   handleChangeColumn: (column: string) => void;
   joinOperator: "AND" | "OR";
   setJoinOperator: (operator: "AND" | "OR") => void;
+  setIsDraggingDisabled: (isDisabled: boolean) => void;
 }
 
 export default function FilterInputs({
@@ -55,6 +56,7 @@ export default function FilterInputs({
   handleDelete,
   index,
   noOfQueries,
+  setIsDraggingDisabled,
 }: IFilterInputsProps) {
   const columnType = selectedColumn ? getFieldType(selectedColumn) : null;
 
@@ -155,28 +157,35 @@ export default function FilterInputs({
               </InputLabel>
 
               <Suspense fallback={<FieldSkeleton />}>
-                {columnType &&
-                  createElement(
-                    query.key === "_rowy_ref.id"
-                      ? IdFilterInput
-                      : getFieldProp("filter.customInput" as any, columnType) ||
-                          getFieldProp("SideDrawerField", columnType),
-                    {
-                      column: selectedColumn,
-                      _rowy_ref: {},
-                      value: query.value,
-                      onSubmit: () => {},
-                      onChange: (value: any) => {
-                        const newQuery = {
-                          ...query,
-                          value,
-                        };
-                        setQuery(newQuery);
-                      },
-                      disabled,
-                      operator: query.operator,
-                    }
-                  )}
+                <div
+                  onMouseEnter={() => setIsDraggingDisabled(true)}
+                  onMouseLeave={() => setIsDraggingDisabled(false)}
+                >
+                  {columnType &&
+                    createElement(
+                      query.key === "_rowy_ref.id"
+                        ? IdFilterInput
+                        : getFieldProp(
+                            "filter.customInput" as any,
+                            columnType
+                          ) || getFieldProp("SideDrawerField", columnType),
+                      {
+                        column: selectedColumn,
+                        _rowy_ref: {},
+                        value: query.value,
+                        onSubmit: () => {},
+                        onChange: (value: any) => {
+                          const newQuery = {
+                            ...query,
+                            value,
+                          };
+                          setQuery(newQuery);
+                        },
+                        disabled,
+                        operator: query.operator,
+                      }
+                    )}
+                </div>
               </Suspense>
             </ErrorBoundary>
           )}

--- a/src/components/TableToolbar/Filters/FilterInputsCollection.tsx
+++ b/src/components/TableToolbar/Filters/FilterInputsCollection.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import FilterInputs from "./FilterInputs";
 
 import { Button } from "@mui/material";
@@ -37,6 +38,8 @@ export default function FilterInputsCollection({
     });
   };
 
+  const [isDraggingDisabled, setIsDraggingDisabled] = useState<boolean>(false);
+
   return (
     <>
       <DragDropContext onDragEnd={onDragEnd}>
@@ -49,6 +52,7 @@ export default function FilterInputsCollection({
                     key={query.id}
                     draggableId={query.id.toString()}
                     index={index}
+                    isDragDisabled={isDraggingDisabled}
                   >
                     {(provided) => (
                       <div
@@ -82,6 +86,9 @@ export default function FilterInputsCollection({
                               newQueries.splice(index, 1);
                               return newQueries;
                             });
+                          }}
+                          setIsDraggingDisabled={(isDisabled: boolean) => {
+                            setIsDraggingDisabled(isDisabled);
                           }}
                           index={index}
                           noOfQueries={queries.length}


### PR DESCRIPTION
We are unable to apply any filters on the slider column type. This issue occurs because the rows in the filter popover are draggable. When attempting to drag the slider, the entire row moves, but the slider itself does not slide.

Fix: Disable the dragging when the mouse enters value input type in the filter popover. 


https://github.com/rowyio/rowy/assets/58873530/d3ef51ce-b9fc-46aa-8d42-d48be93d9419

