### PR TITLE
Bug 1527 2024 03 21

### DIFF
--- a/src/atoms/tableScope/rowActions.ts
+++ b/src/atoms/tableScope/rowActions.ts
@@ -23,6 +23,7 @@ import {
   tableSortsAtom,
   tableRowsDbAtom,
   tableTypeAtom,
+  tablePageAtom,
 } from "./table";
 
 import {
@@ -82,8 +83,7 @@ export const addRowAtom = atom(
     }
 
     const updateTableType = () => {
-      if (tableType === "db") {
-        window.alert("Navigating to Play ground");
+      if (tableType === "db" || (tableType === "old" && tableSort.length)) {
         set(tableTypeAtom, "local");
       }
     };
@@ -186,9 +186,6 @@ export const addRowAtom = atom(
       if (updateInDb) {
         await updateRowDb(row._rowy_ref.path, omitRowyFields(rowValues));
         if (tableType === "local") {
-          window.alert(
-            "As the row added in the playground is updated to the db. so not considering as local row. redirecting it to db"
-          );
           set(tableTypeAtom, "db");
         }
       }
@@ -229,7 +226,6 @@ export const addRowAtom = atom(
             (lRow) => lRow._rowy_ref.path === r._rowy_ref.path
           )
         ) {
-          window.alert("creating the row with already existing custom_id");
           continue;
         }
 
@@ -259,7 +255,6 @@ export const addRowAtom = atom(
           (lRow) => lRow._rowy_ref.path === row._rowy_ref.path
         )
       ) {
-        window.alert("creating the row with already existing custom_id");
         return;
       }
       await _addSingleRowAndAudit(

--- a/src/atoms/tableScope/table.ts
+++ b/src/atoms/tableScope/table.ts
@@ -42,7 +42,7 @@ import { Table } from "@tanstack/react-table";
 /** Root atom from which others are derived */
 export const tableIdAtom = atom("");
 
-export const tableTypeAtom = atom<"db" | "local" | "old">("db");
+export const tableTypeAtom = atom<"db" | "local" | "old">("old");
 
 export const canIncludeLocalDataAtom = atom<boolean>(true);
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -46,6 +46,7 @@ import useHotKeys from "./useHotKey";
 import type { TableRow, ColumnConfig } from "@src/types/table";
 import useStateWithRef from "./useStateWithRef"; // testing with useStateWithRef
 import { Checkbox, FormControlLabel } from "@mui/material";
+import { TableTypeComp } from "@src/pages/Table/TablePage";
 
 export const DEFAULT_ROW_HEIGHT = 41;
 export const DEFAULT_COL_WIDTH = 150;

--- a/src/components/TableToolbar/Filters/Filters.tsx
+++ b/src/components/TableToolbar/Filters/Filters.tsx
@@ -36,6 +36,8 @@ import {
   updateTableSchemaAtom,
   tableFiltersPopoverAtom,
   tableFiltersJoinAtom,
+  tableTypeAtom,
+  canIncludeLocalDataAtom,
 } from "@src/atoms/tableScope";
 import { useFilterInputs } from "./useFilterInputs";
 import { analytics, logEvent } from "@src/analytics";
@@ -88,6 +90,7 @@ export default function Filters() {
     availableFiltersForEachSelectedColumn[0];
 
   const setTableFiltersJoin = useSetAtom(tableFiltersJoinAtom, tableScope);
+  const [tableType] = useAtom(tableTypeAtom, tableScope);
 
   // Get table filters & user filters from config documents
   const tableFilters = useMemoValue(
@@ -353,10 +356,14 @@ export default function Filters() {
                       />
                     }
                     label="Override table filters"
-                    sx={{ justifyContent: "center", mb: 1, mr: 0 }}
+                    sx={
+                      tableType === "old"
+                        ? { justifyContent: "start", mb: 0, mr: 0 }
+                        : { justifyContent: "center", mb: 1, mr: 0 }
+                    }
                   />
                 )}
-
+                <CustomFormControllableForNewTabs />
                 <Stack
                   direction="row"
                   sx={{ "& .MuiButton-root": { minWidth: 100 } }}
@@ -579,4 +586,36 @@ export default function Filters() {
       }}
     </FiltersPopover>
   );
+}
+
+export function CustomFormControllableForNewTabs() {
+  const [tableType] = useAtom(tableTypeAtom, tableScope);
+  const [canIncludeLocalData, setCanIncludeLocalData] = useAtom(
+    canIncludeLocalDataAtom,
+    tableScope
+  );
+  return tableType === "old" ? (
+    <>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={canIncludeLocalData}
+            onChange={(e) => {
+              setCanIncludeLocalData(e.target.checked);
+            }}
+          />
+        }
+        label="Include the Local and out of order rows too."
+        sx={{ justifyContent: "start", mb: 1, mr: 0 }}
+      />
+
+      {/* <Alert severity="info" style={{ width: "auto" }} sx={{ mb: 3 }}>
+        <ul style={{ margin: 0, paddingLeft: "1.5em" }}>
+          <li>
+            The filter above will include the local rows and out of order 
+          </li>
+        </ul>
+      </Alert> */}
+    </>
+  ) : null;
 }

--- a/src/components/TableToolbar/Filters/Filters.tsx
+++ b/src/components/TableToolbar/Filters/Filters.tsx
@@ -192,6 +192,11 @@ export default function Filters() {
   const [overrideTableFilters, setOverrideTableFilters] = useState(
     tableFiltersOverridden
   );
+  const [localDataCheck, setLocalDataCheck] = useState(true);
+  const setCanIncludeLocalData = useSetAtom(
+    canIncludeLocalDataAtom,
+    tableScope
+  );
 
   useEffect(() => {
     if (userSettings.tables?.[tableId]?.joinOperator) {
@@ -363,7 +368,23 @@ export default function Filters() {
                     }
                   />
                 )}
-                <CustomFormControllableForNewTabs />
+                {tableType === "old" ? (
+                  <>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={localDataCheck}
+                          onChange={(e) => {
+                            setLocalDataCheck(e.target.checked);
+                          }}
+                        />
+                      }
+                      label="Include the Local and out of order rows too."
+                      sx={{ justifyContent: "start", mb: 1, mr: 0 }}
+                    />
+                  </>
+                ) : null}
+                {/* <CustomFormControllableForNewTabs /> */}
                 <Stack
                   direction="row"
                   sx={{ "& .MuiButton-root": { minWidth: 100 } }}
@@ -395,6 +416,7 @@ export default function Filters() {
                         userFilterInputs.queries as TableFilter[],
                         userFilterInputs.joinOperator
                       );
+                      setCanIncludeLocalData(localDataCheck);
                       handleClose();
                     }}
                   >
@@ -586,36 +608,4 @@ export default function Filters() {
       }}
     </FiltersPopover>
   );
-}
-
-export function CustomFormControllableForNewTabs() {
-  const [tableType] = useAtom(tableTypeAtom, tableScope);
-  const [canIncludeLocalData, setCanIncludeLocalData] = useAtom(
-    canIncludeLocalDataAtom,
-    tableScope
-  );
-  return tableType === "old" ? (
-    <>
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={canIncludeLocalData}
-            onChange={(e) => {
-              setCanIncludeLocalData(e.target.checked);
-            }}
-          />
-        }
-        label="Include the Local and out of order rows too."
-        sx={{ justifyContent: "start", mb: 1, mr: 0 }}
-      />
-
-      {/* <Alert severity="info" style={{ width: "auto" }} sx={{ mb: 3 }}>
-        <ul style={{ margin: 0, paddingLeft: "1.5em" }}>
-          <li>
-            The filter above will include the local rows and out of order 
-          </li>
-        </ul>
-      </Alert> */}
-    </>
-  ) : null;
 }

--- a/src/components/TableToolbar/Filters/Filters.tsx
+++ b/src/components/TableToolbar/Filters/Filters.tsx
@@ -384,7 +384,6 @@ export default function Filters() {
                     />
                   </>
                 ) : null}
-                {/* <CustomFormControllableForNewTabs /> */}
                 <Stack
                   direction="row"
                   sx={{ "& .MuiButton-root": { minWidth: 100 } }}

--- a/src/components/TableToolbar/LoadedRowsStatus.tsx
+++ b/src/components/TableToolbar/LoadedRowsStatus.tsx
@@ -1,5 +1,5 @@
-import { Suspense, forwardRef } from "react";
-import { useAtom } from "jotai";
+import { Suspense, forwardRef, useEffect } from "react";
+import { useAtom, useSetAtom } from "jotai";
 
 import { Tooltip, Typography, TypographyProps } from "@mui/material";
 import SyncIcon from "@mui/icons-material/Sync";
@@ -10,6 +10,7 @@ import {
   tableRowsAtom,
   tableNextPageAtom,
   serverDocCountAtom,
+  tableTypeAtom,
 } from "@src/atoms/tableScope";
 import { spreadSx } from "@src/utils/ui";
 import useOffline from "@src/hooks/useOffline";
@@ -60,8 +61,8 @@ function LoadedRowsStatus() {
   const [tableNextPage] = useAtom(tableNextPageAtom, tableScope);
   const [serverDocCount] = useAtom(serverDocCountAtom, tableScope);
   const [tableRows] = useAtom(tableRowsAtom, tableScope);
-
-  if (tableNextPage.loading)
+  const [tableType] = useAtom(tableTypeAtom, tableScope);
+  if (tableNextPage.loading && tableType !== "local")
     return <StatusText>{loadingIcon}Loading more…</StatusText>;
 
   return (
@@ -70,8 +71,13 @@ function LoadedRowsStatus() {
         <SyncIcon style={{ transform: "rotate(45deg)" }} />
         Loaded {!tableNextPage.available && "all "}
         {tableRows.length}
-        {serverDocCount !== undefined && ` of ${serverDocCount}`} row
-        {(serverDocCount ?? tableRows.length) !== 1 && "s"}
+        {tableType !== "local" &&
+          serverDocCount !== undefined &&
+          ` of ${serverDocCount}`}{" "}
+        row
+        {tableType !== "local" &&
+          (serverDocCount ?? tableRows.length) !== 1 &&
+          "s"}
       </StatusText>
     </Tooltip>
   );

--- a/src/pages/Table/ProvidedArraySubTablePage.tsx
+++ b/src/pages/Table/ProvidedArraySubTablePage.tsx
@@ -23,6 +23,7 @@ import {
 import { ROUTES } from "@src/constants/routes";
 import { TOP_BAR_HEIGHT } from "@src/layouts/Navigation/TopBar";
 import { TABLE_TOOLBAR_HEIGHT } from "@src/components/TableToolbar";
+import { TableTypeComp } from "./TablePage";
 
 // prettier-ignore
 const TablePage = lazy(() => import("./TablePage" /* webpackChunkName: "TablePage" */));
@@ -148,6 +149,7 @@ export default function ProvidedArraySubTablePage() {
                 "cloud_logs",
               ]}
             />
+            <TableTypeComp />
           </Provider>
         </Suspense>
       </ErrorBoundary>

--- a/src/pages/Table/ProvidedSubTablePage.tsx
+++ b/src/pages/Table/ProvidedSubTablePage.tsx
@@ -23,6 +23,7 @@ import {
 import { ROUTES } from "@src/constants/routes";
 import { TOP_BAR_HEIGHT } from "@src/layouts/Navigation/TopBar";
 import { TABLE_TOOLBAR_HEIGHT } from "@src/components/TableToolbar";
+import { TableTypeComp } from "./TablePage";
 
 // prettier-ignore
 const TablePage = lazy(() => import("./TablePage" /* webpackChunkName: "TablePage" */));
@@ -138,6 +139,7 @@ export default function ProvidedSubTablePage() {
             <DebugAtoms scope={tableScope} />
             <TableSourceFirestore />
             <TablePage enableRowSelection />
+            <TableTypeComp />
           </Provider>
         </Suspense>
       </ErrorBoundary>

--- a/src/pages/Table/ProvidedTablePage.tsx
+++ b/src/pages/Table/ProvidedTablePage.tsx
@@ -31,6 +31,7 @@ import {
 import { SyncAtomValue } from "@src/atoms/utils";
 import { ROUTES } from "@src/constants/routes";
 import useDocumentTitle from "@src/hooks/useDocumentTitle";
+import { TableTypeComp } from "./TablePage";
 
 // prettier-ignore
 const TablePage = lazy(() => import("./TablePage" /* webpackChunkName: "TablePage" */));
@@ -142,6 +143,7 @@ export default function ProvidedTablePage() {
           >
             <main>
               <TablePage enableRowSelection disableModals={Boolean(outlet)} />
+              <TableTypeComp />
             </main>
           </Suspense>
           <Suspense fallback={null}>{outlet}</Suspense>

--- a/src/pages/Table/TablePage.tsx
+++ b/src/pages/Table/TablePage.tsx
@@ -3,7 +3,24 @@ import { useAtom } from "jotai";
 import { ErrorBoundary } from "react-error-boundary";
 import { isEmpty, intersection } from "lodash-es";
 
-import { Box, Fade } from "@mui/material";
+import {
+  Box,
+  Divider,
+  Fade,
+  IconButton,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+  TooltipProps,
+  Typography,
+  Zoom,
+  styled,
+  tooltipClasses,
+} from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+import NewReleasesIcon from "@mui/icons-material/NewReleases";
+
 import ErrorFallback, {
   InlineErrorFallback,
 } from "@src/components/ErrorFallback";
@@ -20,6 +37,8 @@ import TableModals from "@src/components/TableModals";
 import EmptyState from "@src/components/EmptyState";
 import AddRow from "@src/components/TableToolbar/AddRow";
 import { AddRow as AddRowIcon } from "@src/assets/icons";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 
 import {
   projectScope,
@@ -33,6 +52,7 @@ import {
   tableSchemaAtom,
   columnModalAtom,
   tableModalAtom,
+  tableTypeAtom,
 } from "@src/atoms/tableScope";
 import useBeforeUnload from "@src/hooks/useBeforeUnload";
 import ActionParamsProvider from "@src/components/fields/Action/FormDialog/Provider";
@@ -43,6 +63,7 @@ import { DRAWER_COLLAPSED_WIDTH } from "@src/components/SideDrawer";
 import { formatSubTableName } from "@src/utils/table";
 import { TableToolsType } from "@src/types/table";
 import { RowSelectionState } from "@tanstack/react-table";
+import React from "react";
 
 // prettier-ignore
 const BuildLogsSnack = lazy(() => import("@src/components/TableModals/CloudLogsModal/BuildLogs/BuildLogsSnack" /* webpackChunkName: "TableModals-BuildLogsSnack" */));
@@ -162,7 +183,7 @@ export default function TablePage({
         <Suspense fallback={<TableSkeleton />}>
           <Box
             sx={{
-              height: `calc(100vh - ${TOP_BAR_HEIGHT}px - ${TABLE_TOOLBAR_HEIGHT}px)`,
+              height: `calc(95vh - ${TOP_BAR_HEIGHT}px - ${TABLE_TOOLBAR_HEIGHT}px)`,
               width: `calc(100% - ${DRAWER_COLLAPSED_WIDTH}px)`,
               position: "relative",
 
@@ -243,4 +264,140 @@ export default function TablePage({
       )}
     </ActionParamsProvider>
   );
+}
+
+export function TableTypeComp() {
+  const [tableType, setTableType] = useAtom(tableTypeAtom, tableScope);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [tableId] = useAtom(tableIdAtom, tableScope);
+  const handleClick = (event: any) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (type: "db" | "local" | "old") => {
+    setAnchorEl(null);
+    if (type) {
+      setTableType(type);
+    }
+  };
+  const handleChange = (
+    event: React.MouseEvent<HTMLElement>,
+    type: "db" | "local" | "old"
+  ) => {
+    event.preventDefault();
+    if (type !== null) {
+      setTableType(type);
+    }
+  };
+
+  const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+  ))(({ theme }) => ({
+    [`& .${tooltipClasses.tooltip}`]: {
+      backgroundColor: "#f5f5f9",
+      color: "rgba(0, 0, 0, 0.87)",
+      maxWidth: 350,
+      fontSize: theme.typography.pxToRem(12),
+      border: "1px solid #dadde9",
+      marginLeft: "5px",
+    },
+  }));
+
+  return !isEmpty(tableId) ? (
+    <div
+      style={{
+        display: "flex",
+        gap: 15,
+        position: "fixed",
+        bottom: "0px",
+        zIndex: 10,
+        marginLeft: "15px",
+        alignItems: "center",
+      }}
+    >
+      <div style={{ textAlign: "right" }}>
+        <IconButton
+          aria-controls="hamburger-menu"
+          aria-haspopup="true"
+          onClick={handleClick}
+          color="inherit"
+        >
+          <MenuIcon />
+        </IconButton>
+        <Menu
+          id="hamburger-menu"
+          anchorEl={anchorEl}
+          keepMounted
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+          anchorOrigin={{ vertical: "top", horizontal: "left" }}
+          transformOrigin={{ vertical: "bottom", horizontal: "left" }}
+        >
+          <MenuItem onClick={() => handleClose("db")}>
+            <ListItemText>DB</ListItemText>
+          </MenuItem>
+          <Divider />
+          <MenuItem onClick={() => handleClose("local")}>
+            <ListItemText>Local Playground</ListItemText>
+          </MenuItem>
+          <Divider />
+          <MenuItem onClick={() => handleClose("old")}>
+            <ListItemText>Old View</ListItemText>
+          </MenuItem>
+        </Menu>
+      </div>
+      <ToggleButtonGroup
+        value={tableType}
+        exclusive
+        onChange={handleChange}
+        aria-label="Table Tab"
+        size="large"
+      >
+        <ToggleButton value="db" aria-label="Db">
+          DB
+        </ToggleButton>
+        <ToggleButton value="local" aria-label="Local">
+          Local Playground
+        </ToggleButton>
+        <ToggleButton value="old" aria-label="Old">
+          Old View
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <HtmlTooltip
+        TransitionComponent={Zoom}
+        TransitionProps={{ timeout: 200 }}
+        title={
+          <React.Fragment>
+            <Typography variant="body1" color="inherit">
+              Tabs Overview
+            </Typography>
+            <Typography variant="body2">
+              Click on each tab to switch between different views:
+            </Typography>
+            <ul>
+              <li>
+                <strong>Db:</strong> View data from the database.
+              </li>
+              <li>
+                <strong>Local:</strong> View data in the local playground.
+              </li>
+              <li>
+                <strong>Old View:</strong> Switch to the old view.
+              </li>
+            </ul>
+            <span>note: Filters and sorts issue were taken care!</span>
+          </React.Fragment>
+        }
+      >
+        <IconButton
+          aria-controls="hamburger-menu"
+          aria-haspopup="true"
+          color="inherit"
+        >
+          <NewReleasesIcon />
+          {/* <MenuIcon /> */}
+        </IconButton>
+      </HtmlTooltip>
+    </div>
+  ) : null;
 }


### PR DESCRIPTION
/claim #1527

phase1:
This PR addresses the following changes:

1. Resolved issues related to out-of-order sorting and filtering.
2. Implemented tabs feature to facilitate customized data viewing:
      Tab 1: "DB view" displays only database data.
      Tab 2: "Local playground" shows only local data.
      Tab 3: "Old view" allows viewing both database and local data.
3. In user filters added an option to include local data in the "Old view" during sorting and filtering.

Please check the approach in the link below and review the changes made in this pull request and provide feedback on any further improvements that may be necessary. Your input is appreciated.

screen-recording link: https://www.loom.com/share/28025d9212154fad83347632d846652c?sid=5d6abdd8-0274-4ce9-8d42-5dbf105359d1
